### PR TITLE
Fix default tlaplus-cfg language settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
                 "configuration": "./languages/pluscal-lang-config.json"
             },
             {
-                "id": "tlaplus.cfg",
+                "id": "tlaplus_cfg",
                 "aliases": [],
                 "extensions": [
                     ".cfg"
@@ -76,7 +76,7 @@
                 "configuration": "./languages/cfg-lang-config.json"
             },
             {
-                "id": "tlaplus.out",
+                "id": "tlaplus_out",
                 "extensions": [
                     ".out"
                 ]
@@ -94,12 +94,12 @@
                 "path": "./languages/pluscal-grammar.json"
             },
             {
-                "language": "tlaplus.cfg",
+                "language": "tlaplus_cfg",
                 "scopeName": "source.tlaplus.cfg",
                 "path": "./languages/cfg-grammar.json"
             },
             {
-                "language": "tlaplus.out",
+                "language": "tlaplus_out",
                 "scopeName": "source.tlaplus.out",
                 "path": "./languages/out-grammar.json"
             }
@@ -156,7 +156,7 @@
                 },
                 {
                     "command": "tlaplus.model.check.run",
-                    "when": "editorLangId == tlaplus || editorLangId == tlaplus.cfg"
+                    "when": "editorLangId == tlaplus || editorLangId == tlaplus_cfg"
                 },
                 {
                     "command": "tlaplus.model.check.customRun",
@@ -223,7 +223,7 @@
                 "editor.formatOnType": true,
                 "editor.detectIndentation": false
             },
-            "[tlaplus.cfg]": {
+            "[tlaplus_cfg]": {
                 "editor.insertSpaces": true,
                 "editor.tabSize": 2,
                 "editor.formatOnType": true,

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -7,7 +7,7 @@ import { updateCheckResultView, revealEmptyCheckResultView, revealLastCheckResul
 import { applyDCollection } from '../diagnostic';
 import { ChildProcess } from 'child_process';
 import { saveStreamToFile } from '../outputSaver';
-import { replaceExtension } from '../common';
+import { replaceExtension, LANG_TLAPLUS, LANG_TLAPLUS_CFG } from '../common';
 import { ModelCheckResultSource } from '../model/check';
 import { ToolOutputChannel } from '../outputChannels';
 
@@ -39,7 +39,7 @@ export async function checkModel(diagnostic: vscode.DiagnosticCollection, extCon
     if (!doc) {
         return;
     }
-    if (doc.languageId !== 'tlaplus' && doc.languageId !== 'tlaplus.cfg') {
+    if (doc.languageId !== LANG_TLAPLUS && doc.languageId !== LANG_TLAPLUS_CFG) {
         vscode.window.showWarningMessage(
             'File in the active editor is not a .tla or .cfg file, it cannot be checked as a model');
         return;
@@ -56,7 +56,7 @@ export async function checkModelCustom(diagnostic: vscode.DiagnosticCollection, 
     if (!doc) {
         return;
     }
-    if (doc.languageId !== 'tlaplus') {
+    if (doc.languageId !== LANG_TLAPLUS) {
         vscode.window.showWarningMessage('File in the active editor is not a .tla, it cannot be checked as a model');
         return;
     }

--- a/src/commands/parseModule.ts
+++ b/src/commands/parseModule.ts
@@ -4,6 +4,7 @@ import { TranspilerStdoutParser } from '../parsers/pluscal';
 import { SanyData, SanyStdoutParser } from '../parsers/sany';
 import { runPlusCal, runSany } from '../tla2tools';
 import { ToolOutputChannel } from '../outputChannels';
+import { LANG_TLAPLUS } from '../common';
 
 export const CMD_PARSE_MODULE = 'tlaplus.parse';
 
@@ -21,7 +22,7 @@ export function parseModule(diagnostic: vscode.DiagnosticCollection) {
         vscode.window.showWarningMessage('No editor is active, cannot find a TLA+ file to transpile');
         return;
     }
-    if (editor.document.languageId !== 'tlaplus') {
+    if (editor.document.languageId !== LANG_TLAPLUS) {
         vscode.window.showWarningMessage('File in the active editor is not a TLA+ file, it cannot be transpiled');
         return;
     }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
 import * as moment from 'moment';
 
+export const LANG_TLAPLUS = 'tlaplus';
+export const LANG_TLAPLUS_CFG = 'tlaplus_cfg';
+
 /**
  * Thrown when there's some problem with parsing.
  */

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { visualizeTlcOutput, CMD_VISUALIZE_TLC_OUTPUT } from './commands/visuali
 import { TlaOnTypeFormattingEditProvider } from './formatters/tla';
 import { CfgOnTypeFormattingEditProvider } from './formatters/cfg';
 import { TlaCodeActionProvider } from './actions';
+import { LANG_TLAPLUS, LANG_TLAPLUS_CFG } from './common';
 
 // Holds all the error messages
 let diagnostic: vscode.DiagnosticCollection;
@@ -15,7 +16,7 @@ let diagnostic: vscode.DiagnosticCollection;
  * Extension entry point.
  */
 export function activate(context: vscode.ExtensionContext) {
-    diagnostic = vscode.languages.createDiagnosticCollection('tlaplus');
+    diagnostic = vscode.languages.createDiagnosticCollection(LANG_TLAPLUS);
     context.subscriptions.push(
         vscode.commands.registerCommand(
             CMD_PARSE_MODULE,
@@ -39,15 +40,15 @@ export function activate(context: vscode.ExtensionContext) {
             CMD_VISUALIZE_TLC_OUTPUT,
             () => visualizeTlcOutput(context)),
         vscode.languages.registerCodeActionsProvider(
-            { scheme: 'file', language: 'tlaplus' },
+            { scheme: 'file', language: LANG_TLAPLUS },
             new TlaCodeActionProvider(),
             { providedCodeActionKinds: [ vscode.CodeActionKind.Source ] }),
         vscode.languages.registerOnTypeFormattingEditProvider(
-            { scheme: 'file', language: 'tlaplus' },
+            { scheme: 'file', language: LANG_TLAPLUS },
             new TlaOnTypeFormattingEditProvider(),
             '\n', 'd', 'e', 'f', 'r'),
         vscode.languages.registerOnTypeFormattingEditProvider(
-            { scheme: 'file', language: 'tlaplus.cfg' },
+            { scheme: 'file', language: LANG_TLAPLUS_CFG },
             new CfgOnTypeFormattingEditProvider(),
             '\n')
     );

--- a/tests/suite/formatters/cfg.test.ts
+++ b/tests/suite/formatters/cfg.test.ts
@@ -1,12 +1,13 @@
 import * as vscode from 'vscode';
 import { assertOnTypeFormatting, OPT_2_SPACES } from './formatting';
 import { CfgOnTypeFormattingEditProvider } from '../../../src/formatters/cfg';
+import { LANG_TLAPLUS_CFG } from '../../../src/common';
 
 suite('Config On Type Formatting Test Suite', () => {
     let doc: vscode.TextDocument;
 
     suiteSetup(async () => {
-        doc = await vscode.workspace.openTextDocument({ language: 'tlaplus.cfg' });
+        doc = await vscode.workspace.openTextDocument({ language: LANG_TLAPLUS_CFG });
     });
 
     suiteTeardown(async () => {
@@ -54,6 +55,17 @@ suite('Config On Type Formatting Test Suite', () => {
             ], [
                 'CONSTRAINTS',
                 '  '
+            ]
+        );
+    });
+
+    test('Doesn\'t indent if the block already has contents', () => {
+        return assertCfgOnTypeFormatting(doc, [
+                'CONSTANTS Foo = 3',
+                '{enter}'
+            ], [
+                'CONSTANTS Foo = 3',
+                ''
             ]
         );
     });

--- a/tests/suite/formatters/tla.test.ts
+++ b/tests/suite/formatters/tla.test.ts
@@ -1,12 +1,13 @@
 import * as vscode from 'vscode';
 import { assertOnTypeFormatting, OPT_4_SPACES } from './formatting';
 import { TlaOnTypeFormattingEditProvider } from '../../../src/formatters/tla';
+import { LANG_TLAPLUS } from '../../../src/common';
 
 suite('TLA On Type Formatting Test Suite', () => {
     let doc: vscode.TextDocument;
 
     suiteSetup(async () => {
-        doc = await vscode.workspace.openTextDocument({ language: 'tlaplus' });
+        doc = await vscode.workspace.openTextDocument({ language: LANG_TLAPLUS });
     });
 
     suiteTeardown(async () => {


### PR DESCRIPTION
Because the `configurationDefaults` setting doesn't work for languages with dots in their names.