### PR TITLE
Auto completion improvements

### DIFF
--- a/src/completions/tlaCompletions.ts
+++ b/src/completions/tlaCompletions.ts
@@ -6,14 +6,17 @@ export const TLA_OPERATORS = [
     'E', 'A', 'X', 'lnot', 'land', 'lor', 'cdot', 'equiv', 'subseteq', 'in', 'notin', 'intersect',
     'union', 'leq', 'geq', 'cup', 'cap'
 ];
-export const TLA_STARTING_KEYWORDS = [  // These keywords start blocks, should not be in the middle of an expression
-    'EXTENDS', 'VARIABLE', 'VARIABLES', 'CONSTANT', 'CONSTANTS', 'ASSUME', 'ASSUMPTION', 'AXIOM', 'THEOREM', 'DEFINE',
-    'PROOF', 'LEMMA', 'PROPOSITION', 'COROLLARY', 'QED', 'SUFFICES', 'RECURSIVE'
+export const TLA_STARTING_KEYWORDS = [  // These keywords start blocks, and should not be in the middle of an expression
+    'EXTENDS', 'VARIABLE', 'VARIABLES', 'CONSTANT', 'CONSTANTS', 'ASSUME', 'ASSUMPTION', 'AXIOM', 'THEOREM',
+    'PROOF', 'LEMMA', 'PROPOSITION', 'COROLLARY', 'RECURSIVE'
+];
+export const TLA_PROOF_STARTING_KEYWORDS = [ // These keywords start proof steps
+    'DEFINE', 'QED', 'HIDE', 'SUFFICES', 'PICK', 'HAVE', 'TAKE', 'WITNESS'
 ];
 export const TLA_OTHER_KEYWORDS = [     // These keywords can be found pretty everywhere
     'LET', 'IN', 'EXCEPT', 'ENABLED', 'UNCHANGED', 'LAMBDA', 'DOMAIN', 'CHOOSE', 'LOCAL',
-    'INSTANCE', 'WITH', 'SUBSET', 'UNION', 'SF_', 'WF_', 'USE', 'DEFS', 'BY', 'DEF', 'PROVE', 'OBVIOUS',
-    'NEW', 'PICK', 'HIDE', 'WITNESS', 'HAVE', 'TAKE', 'ACTION', 'OMITTED', 'ONLY', 'STATE', 'TEMPORAL',
+    'INSTANCE', 'WITH', 'SUBSET', 'UNION', 'SF_', 'WF_', 'USE', 'BY', 'DEF', 'DEFS', 'PROVE', 'OBVIOUS',
+    'NEW', 'ACTION', 'OMITTED', 'ONLY', 'STATE', 'TEMPORAL',
     // -- control keywords
     'IF', 'THEN', 'ELSE', 'CASE', 'OTHER',
     // -- other
@@ -25,6 +28,9 @@ export const TLA_STD_MODULES = [
 ];
 
 const TLA_STARTING_KEYWORD_ITEMS = TLA_STARTING_KEYWORDS.map(w => {
+    return new vscode.CompletionItem(w, vscode.CompletionItemKind.Keyword);
+});
+const TLA_PROOF_STARTING_KEYWORD_ITEMS = TLA_PROOF_STARTING_KEYWORDS.map(w => {
     return new vscode.CompletionItem(w, vscode.CompletionItemKind.Keyword);
 });
 const TLA_OTHER_KEYWORD_ITEMS = TLA_OTHER_KEYWORDS.map(w => {
@@ -66,12 +72,17 @@ export class TlaCompletionItemProvider implements vscode.CompletionItemProvider 
         }
         const docInfo = this.docInfos.get(document.uri);
         const isPlusCal = docInfo.plusCalRange ? docInfo.plusCalRange.contains(position) : false;
-        const isNewLine = /^[\s<>\d\.]*[a-zA-Z]*$/g.test(prevText);
         const symbols = docInfo.symbols || [];
         const symbolInfos = symbols.map(s => new vscode.CompletionItem(s.name, mapKind(s.kind)));
         let items = TLA_INNER_ITEMS.concat(symbolInfos);
-        if (isNewLine && !isPlusCal) {
-            items = items.concat(TLA_STARTING_KEYWORD_ITEMS);
+        if (!isPlusCal) {
+            const isProofStep = /^\s*<\d+>[<>\d\.a-zA-Z]*\s+[a-zA-Z]*$/g.test(prevText);
+            const isNewLine = /^\s*[a-zA-Z]*$/g.test(prevText);
+            if (isProofStep) {
+                items = items.concat(TLA_PROOF_STARTING_KEYWORD_ITEMS);
+            } else if (isNewLine) {
+                items = items.concat(TLA_STARTING_KEYWORD_ITEMS);
+            }
         }
         return new vscode.CompletionList(items, false);
     }

--- a/src/completions/tlaCompletions.ts
+++ b/src/completions/tlaCompletions.ts
@@ -57,6 +57,9 @@ export class TlaCompletionItemProvider implements vscode.CompletionItemProvider 
         if (prevText.startsWith('EXTENDS')) {
             return new vscode.CompletionList(TLA_STD_MODULE_ITEMS, false);
         }
+        if (prevText.startsWith('CONSTANT')) {
+            return new vscode.CompletionList([], false);
+        }
         const isOperator = /^.*(?<!\/)\\\w*$/g.test(prevText);  // contains \ before the trailing letters, but not /\
         if (isOperator) {
             return new vscode.CompletionList(TLA_OPERATOR_ITEMS, false);

--- a/src/completions/tlaCompletions.ts
+++ b/src/completions/tlaCompletions.ts
@@ -8,10 +8,10 @@ export const TLA_OPERATORS = [
 ];
 export const TLA_STARTING_KEYWORDS = [  // These keywords start blocks, should not be in the middle of an expression
     'EXTENDS', 'VARIABLE', 'VARIABLES', 'CONSTANT', 'CONSTANTS', 'ASSUME', 'ASSUMPTION', 'AXIOM', 'THEOREM', 'DEFINE',
-    'PROOF', 'LEMMA', 'PROPOSITION', 'COROLLARY', 'QED', 'SUFFICES'
+    'PROOF', 'LEMMA', 'PROPOSITION', 'COROLLARY', 'QED', 'SUFFICES', 'RECURSIVE'
 ];
 export const TLA_OTHER_KEYWORDS = [     // These keywords can be found pretty everywhere
-    'LET', 'IN', 'EXCEPT', 'ENABLED', 'UNCHANGED', 'LAMBDA', 'DOMAIN', 'CHOOSE', 'LOCAL', 'RECURSIVE',
+    'LET', 'IN', 'EXCEPT', 'ENABLED', 'UNCHANGED', 'LAMBDA', 'DOMAIN', 'CHOOSE', 'LOCAL',
     'INSTANCE', 'WITH', 'SUBSET', 'UNION', 'SF_', 'WF_', 'USE', 'DEFS', 'BY', 'DEF', 'PROVE', 'OBVIOUS',
     'NEW', 'PICK', 'HIDE', 'WITNESS', 'HAVE', 'TAKE', 'ACTION', 'OMITTED', 'ONLY', 'STATE', 'TEMPORAL',
     // -- control keywords
@@ -57,7 +57,7 @@ export class TlaCompletionItemProvider implements vscode.CompletionItemProvider 
         if (prevText.startsWith('EXTENDS')) {
             return new vscode.CompletionList(TLA_STD_MODULE_ITEMS, false);
         }
-        if (prevText.startsWith('CONSTANT')) {
+        if (prevText.startsWith('CONSTANT') || prevText.startsWith('RECURSIVE')) {
             return new vscode.CompletionList([], false);
         }
         const isOperator = /^.*(?<!\/)\\\w*$/g.test(prevText);  // contains \ before the trailing letters, but not /\

--- a/src/completions/tlaCompletions.ts
+++ b/src/completions/tlaCompletions.ts
@@ -20,6 +20,9 @@ export const TLA_OTHER_KEYWORDS = [     // These keywords can be found pretty ev
     'BOOLEAN'
 ];
 export const TLA_CONSTANTS = [ 'TRUE', 'FALSE' ];
+export const TLA_STD_MODULES = [
+    'Bags', 'FiniteSets', 'Integers', 'Naturals', 'Randomization', 'Reals', 'RealTime', 'Sequences', 'TLC'
+];
 
 const TLA_STARTING_KEYWORD_ITEMS = TLA_STARTING_KEYWORDS.map(w => {
     return new vscode.CompletionItem(w, vscode.CompletionItemKind.Keyword);
@@ -32,6 +35,9 @@ const TLA_OPERATOR_ITEMS = TLA_OPERATORS.map(w => {
     return new vscode.CompletionItem('\\' + w, vscode.CompletionItemKind.Operator);
 });
 const TLA_INNER_ITEMS = TLA_OTHER_KEYWORD_ITEMS.concat(TLA_CONST_ITEMS);
+const TLA_STD_MODULE_ITEMS = TLA_STD_MODULES.map(m => {
+    return new vscode.CompletionItem(m, vscode.CompletionItemKind.Module);
+});
 
 /**
  * Completes TLA+ text.
@@ -48,6 +54,9 @@ export class TlaCompletionItemProvider implements vscode.CompletionItemProvider 
         context: vscode.CompletionContext
     ): vscode.ProviderResult<vscode.CompletionList> {
         const prevText = getPrevText(document, position);
+        if (prevText.startsWith('EXTENDS')) {
+            return new vscode.CompletionList(TLA_STD_MODULE_ITEMS, false);
+        }
         const isOperator = /^.*(?<!\/)\\\w*$/g.test(prevText);  // contains \ before the trailing letters, but not /\
         if (isOperator) {
             return new vscode.CompletionList(TLA_OPERATOR_ITEMS, false);

--- a/tests/suite/completions/tlaCompletions.test.ts
+++ b/tests/suite/completions/tlaCompletions.test.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
 import { LANG_TLAPLUS } from '../../../src/common';
-import { TlaCompletionItemProvider, TLA_CONSTANTS, TLA_STARTING_KEYWORDS, TLA_OTHER_KEYWORDS, TLA_OPERATORS
-    } from '../../../src/completions/tlaCompletions';
+import { TlaCompletionItemProvider, TLA_CONSTANTS, TLA_STARTING_KEYWORDS, TLA_OTHER_KEYWORDS, TLA_OPERATORS,
+    TLA_STD_MODULES } from '../../../src/completions/tlaCompletions';
 import { parseDocInfo, replaceDocContents } from '../document';
 import { loc, pos } from '../shortcuts';
 import { TlaDocumentInfos } from '../../../src/model/documentInfo';
@@ -13,6 +13,7 @@ const EXPECT_OTHER_KEYWORDS = 2;
 const EXPECT_CONSTANTS = 4;
 const EXPECT_OPERATORS = 8;
 const EXPECT_SYMBOLS = 16;
+const EXPECT_STD_MODULES = 32;
 const EXPECT_INNER_CLASS = EXPECT_OTHER_KEYWORDS | EXPECT_CONSTANTS | EXPECT_SYMBOLS;
 
 const PREFIXED_OPERATORS = TLA_OPERATORS.map((op) => '\\' + op);
@@ -71,6 +72,11 @@ suite('TLA Completions Provider Test Suite', () => {
         ], EXPECT_INNER_CLASS);
     });
 
+    test('Completes std modules after EXTENDS', () => {
+        return assertCompletions(doc, [
+            'EXTENDS {r}'
+        ], EXPECT_STD_MODULES);
+    });
 });
 
 async function assertCompletions(
@@ -109,6 +115,9 @@ async function assertCompletions(
     if ((expectFlags & EXPECT_SYMBOLS) !== 0) {
         total += assertSymbols(completions);
     }
+    if ((expectFlags & EXPECT_STD_MODULES) !== 0) {
+        total += assertStdModules(completions);
+    }
     assert.equal(
         total,
         completions.items.length,
@@ -136,6 +145,10 @@ function assertOperators(list: vscode.CompletionList): number {
 function assertSymbols(list: vscode.CompletionList) {
     assertCompletion('Foo', vscode.CompletionItemKind.Field, list);
     return 1;
+}
+
+function assertStdModules(list: vscode.CompletionList) {
+    return assertSymbolClass(TLA_STD_MODULES, vscode.CompletionItemKind.Module, list);
 }
 
 function assertSymbolClass(labels: string[], expKind: vscode.CompletionItemKind, list: vscode.CompletionList): number {


### PR DESCRIPTION
Complete standard module names
Don't complete constant names
Smarter completion for RECURSIVE
Remove proof-related keywords from completion list in non-proof blocks