### PR TITLE
Implement DefinitionProvider interface to support "Go To Definition"

### DIFF
--- a/src/declarations/tlaDeclarations.ts
+++ b/src/declarations/tlaDeclarations.ts
@@ -1,10 +1,28 @@
 import * as vscode from 'vscode';
-import { TlaDocumentInfos } from '../model/documentInfo';
+import { TlaDocumentInfos, TlaDocumentInfo } from '../model/documentInfo';
+
+function symbolLocations(document: vscode.TextDocument, docInfo: TlaDocumentInfo, position: vscode.Position) {
+    const range = document.getWordRangeAtPosition(position);
+    if (!range) {
+        return undefined;
+    }
+    const word = document.lineAt(position.line).text.substring(range.start.character, range.end.character);
+    const symbols = (docInfo.plusCalRange && docInfo.plusCalRange.contains(position))
+        ? docInfo.symbols.concat(docInfo.plusCalSymbols)
+        : docInfo.symbols;
+    const locations = [];
+    for (const symbol of symbols) {
+        if (symbol.name === word && symbol.location.range.start.isBeforeOrEqual(range.start)) {
+            locations.push(symbol.location);
+        }
+    }
+    return locations;
+}
 
 export class TlaDeclarationsProvider implements vscode.DeclarationProvider {
     constructor(
         private docInfos: TlaDocumentInfos
-    ) {}
+    ) { }
 
     provideDeclaration(
         document: vscode.TextDocument,
@@ -15,20 +33,24 @@ export class TlaDeclarationsProvider implements vscode.DeclarationProvider {
         if (!docInfo) {
             return undefined;
         }
-        const range = document.getWordRangeAtPosition(position);
-        if (!range) {
+        return symbolLocations(document, docInfo, position);
+    }
+}
+
+export class TlaDefinitionsProvider implements vscode.DefinitionProvider {
+    constructor(
+        private docInfos: TlaDocumentInfos
+    ) { }
+
+    provideDefinition(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.Declaration> {
+        const docInfo = this.docInfos.get(document.uri);
+        if (!docInfo) {
             return undefined;
         }
-        const word = document.lineAt(position.line).text.substring(range.start.character, range.end.character);
-        const symbols = (docInfo.plusCalRange && docInfo.plusCalRange.contains(position))
-            ? docInfo.symbols.concat(docInfo.plusCalSymbols)
-            : docInfo.symbols;
-        const locations = [];
-        for (const symbol of symbols) {
-            if (symbol.name === word && symbol.location.range.start.isBeforeOrEqual(range.start)) {
-                locations.push(symbol.location);
-            }
-        }
-        return locations;
+        return symbolLocations(document, docInfo, position);
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import { TlaDocumentSymbolsProvider } from './symbols/tlaSymbols';
 import { LANG_TLAPLUS, LANG_TLAPLUS_CFG, exists, readFile, writeFile } from './common';
 import { TlaCompletionItemProvider } from './completions/tlaCompletions';
 import { CfgCompletionItemProvider } from './completions/cfgCompletions';
-import { TlaDeclarationsProvider } from './declarations/tlaDeclarations';
+import { TlaDeclarationsProvider, TlaDefinitionsProvider } from './declarations/tlaDeclarations';
 import { TlaDocumentInfos } from './model/documentInfo';
 import { syncTlcStatisticsSetting, listenTlcStatConfigurationChanges } from './commands/tlcStatisticsCfg';
 
@@ -93,6 +93,10 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerDeclarationProvider(
             TLAPLUS_FILE_SELECTOR,
             new TlaDeclarationsProvider(tlaDocInfos)
+        ),
+        vscode.languages.registerDefinitionProvider(
+            TLAPLUS_FILE_SELECTOR,
+            new TlaDefinitionsProvider(tlaDocInfos)
         )
     );
     syncTlcStatisticsSetting()


### PR DESCRIPTION
Hi @alygin, I figured I would take a shot at addressing #138, since it seemed pretty simple. From my reading of the code the necessary functionality already existed in the `TlaDeclarationsProvider` class, but it seems that the [`DefinitionProvider`](https://code.visualstudio.com/api/references/vscode-api#DefinitionProvider) interface needs to be implemented to support "Go To Definition" with Cmd + Click functionality. So, I factored out the logic so the implementations of `DeclarationProvider` and `DefinitionProvider` can share the same code. 

If the layout of this patch doesn't match your standards, feel free to alter it or give me feedback on how I could fix it. I added a few very simple tests and ran the full extension test suite which passed (201 tests ran). I have also tested the patch out manually on a few TLA+ specs and the Cmd + Click "Go To Definition" behavior all seems to work as expected.

Btw, your instructions in [CONTRIBUTING.md](https://github.com/alygin/vscode-tlaplus/blob/master/CONTRIBUTING.md) were super helpful for getting up and running.