### PR TITLE
Handle TLC errors when -continue option is used

### DIFF
--- a/src/model/check.ts
+++ b/src/model/check.ts
@@ -415,7 +415,7 @@ export class ModelCheckResult {
         readonly processInfo: string | undefined,
         readonly initialStatesStat: InitialStateStatItem[],
         readonly coverageStat: CoverageItem[],
-        readonly warnings: string[][],
+        readonly warnings: MessageLine[][],
         readonly errors: MessageLine[][],
         readonly errorTrace: ErrorTraceItem[],
         readonly sanyMessages: DCollection | undefined,

--- a/src/parsers/tlc.ts
+++ b/src/parsers/tlc.ts
@@ -344,7 +344,9 @@ class ModelCheckResultBuilder {
                 break;
             case msg.TLC_SUCCESS:
                 this.parseSuccess(message.lines);
-                this.state = CheckState.Success;
+                if (this.errors.length === 0) {   // There might be error messages if the -continue option was used
+                    this.state = CheckState.Success;
+                }
                 break;
             case msg.TLC_FINISHED:
                 this.status = CheckStatus.Finished;

--- a/src/parsers/tlc.ts
+++ b/src/parsers/tlc.ts
@@ -173,7 +173,7 @@ class ModelCheckResultBuilder {
     private processInfo: string | undefined;
     private initialStatesStat: InitialStateStatItem[] = [];
     private coverageStat: CoverageItem[] = [];
-    private warnings: string[][] = [];
+    private warnings: MessageLine[][] = [];
     private errors: MessageLine[][] = [];
     private errorTrace: ErrorTraceItem[] = [];
     private messages = new MessageStack();
@@ -475,7 +475,8 @@ class ModelCheckResultBuilder {
         if (lines.length === 0) {
             return;
         }
-        this.warnings.push(lines);
+        const msgLines = lines.map((l) => this.makeMessageLine(l));
+        this.warnings.push(msgLines);
     }
 
     private parseErrorMessage(lines: string[]) {

--- a/tests/fixtures/parsers/tlc/error-continue.out
+++ b/tests/fixtures/parsers/tlc/error-continue.out
@@ -1,0 +1,68 @@
+@!@!@STARTMSG 2262:0 @!@!@
+TLC2 Version 2.14 of 10 July 2019 (rev: 0cae24f)
+@!@!@ENDMSG 2262 @!@!@
+@!@!@STARTMSG 2187:0 @!@!@
+Running breadth-first search Model-Checking with fp 22 and seed -5755320172003082571 with 1 worker on 4 cores with 1820MB heap and 64MB offheap memory [pid: 91333] (Mac OS X 10.14.5 x86_64, Amazon.com Inc. 11.0.3 x86_64, MSBDiskFPSet, DiskStateQueue).
+@!@!@ENDMSG 2187 @!@!@
+@!@!@STARTMSG 2220:0 @!@!@
+Starting SANY...
+@!@!@ENDMSG 2220 @!@!@
+Parsing file /Users/bob/example.tla
+Semantic processing of module example
+@!@!@STARTMSG 2219:0 @!@!@
+SANY finished.
+@!@!@ENDMSG 2219 @!@!@
+@!@!@STARTMSG 2185:0 @!@!@
+Starting... (2019-08-17 00:11:08)
+@!@!@ENDMSG 2185 @!@!@
+@!@!@STARTMSG 2189:0 @!@!@
+Computing initial states...
+@!@!@ENDMSG 2189 @!@!@
+@!@!@STARTMSG 2190:0 @!@!@
+Finished computing initial states: 1 distinct state generated at 2019-08-17 00:11:08.
+@!@!@ENDMSG 2190 @!@!@
+@!@!@STARTMSG 2110:1 @!@!@
+Invariant FooInvariant is violated.
+@!@!@ENDMSG 2110 @!@!@
+@!@!@STARTMSG 2121:1 @!@!@
+The behavior up to this point is:
+@!@!@ENDMSG 2121 @!@!@
+@!@!@STARTMSG 2217:4 @!@!@
+1: <Initial predicate>
+/\ FooVar = 1..2
+/\ BarVar = -1
+
+@!@!@ENDMSG 2217 @!@!@
+@!@!@STARTMSG 2193:0 @!@!@
+Model checking completed. No error has been found.
+  Estimates of the probability that TLC did not check all reachable states
+  because two distinct states had the same fingerprint:
+  calculated (optimistic):  val = 1.1E-19
+@!@!@ENDMSG 2193 @!@!@
+@!@!@STARTMSG 2201:0 @!@!@
+The coverage statistics at 2019-08-17 00:11:08
+@!@!@ENDMSG 2201 @!@!@
+@!@!@STARTMSG 2773:0 @!@!@
+<Init line 14, col 1 to line 14, col 4 of module example>: 1:1
+@!@!@ENDMSG 2773 @!@!@
+@!@!@STARTMSG 2221:0 @!@!@
+  line 14, col 9 to line 14, col 23 of module example: 1
+@!@!@ENDMSG 2221 @!@!@
+@!@!@STARTMSG 2202:0 @!@!@
+End of statistics.
+@!@!@ENDMSG 2202 @!@!@
+@!@!@STARTMSG 2200:0 @!@!@
+Progress(2) at 2019-08-17 00:11:09: 3 states generated (204 s/min), 2 distinct states found (136 ds/min), 0 states left on queue.
+@!@!@ENDMSG 2200 @!@!@
+@!@!@STARTMSG 2199:0 @!@!@
+3 states generated, 2 distinct states found, 0 states left on queue.
+@!@!@ENDMSG 2199 @!@!@
+@!@!@STARTMSG 2194:0 @!@!@
+The depth of the complete state graph search is 2.
+@!@!@ENDMSG 2194 @!@!@
+@!@!@STARTMSG 2268:0 @!@!@
+The average outdegree of the complete state graph is 1 (minimum is 0, the maximum 1 and the 95th percentile is 1).
+@!@!@ENDMSG 2268 @!@!@
+@!@!@STARTMSG 2186:0 @!@!@
+Finished in 886ms at (2019-08-17 00:11:09)
+@!@!@ENDMSG 2186 @!@!@

--- a/tests/suite/parsers/tlc.test.ts
+++ b/tests/suite/parsers/tlc.test.ts
@@ -68,7 +68,7 @@ suite('TLC Output Parser Test Suite', () => {
 
     test('Respects severity levels', () => {
         return assertOutput('severity-levels.out', ROOT_PATH,
-            new CheckResultBuilder('foo', CheckState.Success, CheckStatus.Finished)
+            new CheckResultBuilder('foo', CheckState.Error, CheckStatus.Finished)
                 .setStartDateTime('2019-01-01 01:02:03')
                 .setEndDateTime('2019-01-01 01:02:05')
                 .setDuration(2345)
@@ -99,6 +99,30 @@ suite('TLC Output Parser Test Suite', () => {
                 .addInitState('00:00:00', 0, 1, 1, 1)
                 .addInitState('00:00:01', 2, 3, 2, 0)
                 .addCoverage('example', 'Init', '/Users/bob/example.tla', range(13, 0, 13, 4), 1, 1)
+                .build()
+            );
+    });
+
+    test('Reports failure when errors are present', () => {
+        // The check state is Error despite the 2193 (TLC_SUCCESS) message.
+        // It happens when the -continue option is used.
+        return assertOutput('error-continue.out', ROOT_PATH,
+            new CheckResultBuilder('error-continue.out', CheckState.Error, CheckStatus.Finished)
+                .addDColFilePath('/Users/bob/example.tla')
+                .setStartDateTime('2019-08-17 00:11:08')
+                .setEndDateTime('2019-08-17 00:11:09')
+                .setDuration(886)
+                .setProcessInfo(
+                    'Running breadth-first search Model-Checking with fp 22 and seed -5755320172003082571'
+                        + ' with 1 worker on 4 cores with 1820MB heap and 64MB offheap memory [pid: 91333]'
+                        + ' (Mac OS X 10.14.5 x86_64, Amazon.com Inc. 11.0.3 x86_64, MSBDiskFPSet, DiskStateQueue).')
+                .addInitState('00:00:00', 0, 1, 1, 1)
+                .addInitState('00:00:01', 2, 3, 2, 0)
+                .addCoverage('example', 'Init', '/Users/bob/example.tla', range(13, 0, 13, 4), 1, 1)
+                .addError([message('Invariant FooInvariant is violated.')])
+                .addTraceItem(1, 'Initial predicate', '', '', undefined, range(0, 0, 0, 0),
+                    struct('', v('FooVar', '1..2'), v('BarVar', '-1'))
+                )
                 .build()
             );
     });

--- a/tests/suite/parsers/tlc.test.ts
+++ b/tests/suite/parsers/tlc.test.ts
@@ -74,7 +74,7 @@ suite('TLC Output Parser Test Suite', () => {
                 .setDuration(2345)
                 .addInitState('00:00:00', 0, 5184, 5184, 5184)
                 .addOutLine('Info message.')
-                .addWarning(['Warning message.'])
+                .addWarning([message('Warning message.')])
                 .addError([message('Error message.')])
                 .addError([message('TLC bug info.')])
                 .build()
@@ -89,8 +89,8 @@ suite('TLC Output Parser Test Suite', () => {
                 .setEndDateTime('2019-08-17 00:11:09')
                 .setDuration(886)
                 .addWarning([
-                    'Please run the Java VM which executes TLC with a throughput optimized garbage collector'
-                    + ' by passing the "-XX:+UseParallelGC" property.'
+                    message('Please run the Java VM which executes TLC with a throughput optimized garbage collector'
+                    + ' by passing the "-XX:+UseParallelGC" property.')
                 ])
                 .setProcessInfo(
                     'Running breadth-first search Model-Checking with fp 22 and seed -5755320172003082571'

--- a/tests/suite/shortcuts.ts
+++ b/tests/suite/shortcuts.ts
@@ -100,7 +100,7 @@ export class CheckResultBuilder {
     private processInfo: string | undefined;
     private initialStatesStat: InitialStateStatItem[] = [];
     private coverageStat: CoverageItem[] = [];
-    private warnings: string[][] = [];
+    private warnings: MessageLine[][] = [];
     private errors: MessageLine[][] = [];
     private errorTrace: ErrorTraceItem[] = [];
     private sanyMessages: DCollection | undefined;
@@ -194,7 +194,7 @@ export class CheckResultBuilder {
         return this;
     }
 
-    addWarning(lines: string[]): CheckResultBuilder {
+    addWarning(lines: MessageLine[]): CheckResultBuilder {
         this.warnings.push(lines);
         return this;
     }


### PR DESCRIPTION
Set check result to Error when there were errors even with the `-continue` option and despite the `TLC_SUCCESS` message.
ref #143 