### PR TITLE
Check model from explorer context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,18 +212,28 @@
                     "when": "editorLangId == tlaplus"
                 }
             ],
+            "explorer/context": [
+                {
+                    "command": "tlaplus.model.check.run",
+                    "when": "resourceLangId == tlaplus || resourceLangId == tlaplus_cfg",
+                    "group": "z_commands"
+                }
+            ],
             "editor/context": [
                 {
                     "command": "tlaplus.model.check.run",
-                    "when": "editorLangId == tlaplus || editorLangId == tlaplus_cfg"
+                    "when": "editorLangId == tlaplus || editorLangId == tlaplus_cfg",
+                    "group": "z_commands"
                 },
                 {
                     "command": "tlaplus.out.visualize",
-                    "when": "resourceExtname == .out"
+                    "when": "resourceExtname == .out",
+                    "group": "z_commands"
                 },
                 {
                     "command": "tlaplus.evaluateSelection",
-                    "when": "editorLangId == tlaplus"
+                    "when": "editorLangId == tlaplus",
+                    "group": "z_commands"
                 }
             ]
         },

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -39,18 +39,16 @@ export class SpecFiles {
 /**
  * Runs TLC on a TLA+ specification.
  */
-export async function checkModel(diagnostic: vscode.DiagnosticCollection, extContext: vscode.ExtensionContext) {
-    const editor = getEditorIfCanRunTlc(extContext);
-    if (!editor) {
+export async function checkModel(
+    fileUri: vscode.Uri | undefined,
+    diagnostic: vscode.DiagnosticCollection,
+    extContext: vscode.ExtensionContext
+) {
+    const uri = fileUri ? fileUri : getActiveEditorFileUri(extContext);
+    if (!uri) {
         return;
     }
-    const doc = editor.document;
-    if (doc.languageId !== LANG_TLAPLUS && doc.languageId !== LANG_TLAPLUS_CFG) {
-        vscode.window.showWarningMessage(
-            'File in the active editor is not a .tla or .cfg file, it cannot be checked as a model');
-        return;
-    }
-    const specFiles = await getSpecFiles(doc.uri);
+    const specFiles = await getSpecFiles(uri);
     if (!specFiles) {
         return;
     }
@@ -103,6 +101,20 @@ export function stopModelChecking() {
 
 export function showTlcOutput() {
     outChannel.revealWindow();
+}
+
+function getActiveEditorFileUri(extContext: vscode.ExtensionContext): vscode.Uri | undefined {
+    const editor = getEditorIfCanRunTlc(extContext);
+    if (!editor) {
+        return undefined;
+    }
+    const doc = editor.document;
+    if (doc.languageId !== LANG_TLAPLUS && doc.languageId !== LANG_TLAPLUS_CFG) {
+        vscode.window.showWarningMessage(
+            'File in the active editor is not a .tla or .cfg file, it cannot be checked as a model');
+        return undefined;
+    }
+    return doc.uri;
 }
 
 export function getEditorIfCanRunTlc(extContext: vscode.ExtensionContext): vscode.TextEditor | undefined {

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ export function activate(context: vscode.ExtensionContext) {
             () => exportModuleToPdf(context)),
         vscode.commands.registerCommand(
             CMD_CHECK_MODEL_RUN,
-            () => checkModel(diagnostic, context)),
+            (uri) => checkModel(uri, diagnostic, context)),
         vscode.commands.registerCommand(
             CMD_CHECK_MODEL_CUSTOM_RUN,
             () => checkModelCustom(diagnostic, context)),


### PR DESCRIPTION
Adds the `fileUri` parameter to the `tlaplus.model.check.run` command, which makes it possible to run the command without having an open editor with a .tla/.cfg file.

Puts the `Check model` item to the Explorer context menu for .tla and .cfg files.

ref #115