### PR TITLE
Rename "Repeat" and display spec/model file names

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,8 +135,8 @@
                 "category": "TLA+"
             },
             {
-                "command": "tlaplus.model.check.repeat",
-                "title": "Repeat last model check",
+                "command": "tlaplus.model.check.runAgain",
+                "title": "Run last model check again",
                 "category": "TLA+"
             },
             {
@@ -197,8 +197,8 @@
                     "when": "editorLangId == tlaplus || editorLangId == tlaplus_cfg"
                 },
                 {
-                    "command": "tlaplus.model.check.repeat",
-                    "when": "tlaplus.tlc.canRepeat"
+                    "command": "tlaplus.model.check.runAgain",
+                    "when": "tlaplus.tlc.canRunAgain"
                 },
                 {
                     "command": "tlaplus.model.check.customRun",

--- a/resources/check-result-view.css
+++ b/resources/check-result-view.css
@@ -19,6 +19,7 @@ h1 {
 .action {
     display: inline-block;
     margin-left: 1em;
+    white-space: nowrap;
 }
 
 .header::after {

--- a/resources/check-result-view.css
+++ b/resources/check-result-view.css
@@ -72,6 +72,10 @@ th {
     color: var(--vscode-errorForeground);
 }
 
+.spec-files {
+    margin-bottom: 1em;
+}
+
 .check-status-details {
     display: inline-block;
 }

--- a/resources/check-result-view.html
+++ b/resources/check-result-view.html
@@ -32,7 +32,7 @@
     <div class="header">
       <div id="actions" class="header-actions">
         <div id="act-run-again" class="action">
-          <a href="#" title="Run this check again">Run again</a>
+          <a href="#" title="Run this check again">Check again</a>
         </div>
         <div id="act-show-output" class="action">
           <a href="#" title="Display full TLC output">Full output</a>
@@ -41,6 +41,9 @@
       <h1>Status</h1>
     </div>
     <p>
+      <div id="spec-files" class="spec-files">
+        Checking <span id="tla-file-name" title="Spec file name">-</span> / <span id="cfg-file-name" title="Model file name">-</span>
+      </div>
       <span id="check-state">-</span>
       <span id="cmd-stop-wrapper">(<a id="cmd-stop" href="#stop">stop</a>)</span>
       <span id="check-status-details" class="check-status-details">-</span>

--- a/resources/check-result-view.html
+++ b/resources/check-result-view.html
@@ -31,8 +31,8 @@
   <section>
     <div class="header">
       <div id="actions" class="header-actions">
-        <div id="act-repeat" class="action">
-          <a href="#" title="Repeat this check">Repeat</a>
+        <div id="act-run-again" class="action">
+          <a href="#" title="Run this check again">Run again</a>
         </div>
         <div id="act-show-output" class="action">
           <a href="#" title="Display full TLC output">Full output</a>

--- a/resources/check-result-view.js
+++ b/resources/check-result-view.js
@@ -58,6 +58,7 @@ function displayCheckResult(state) {
         return;
     }
     displayStatus(res);
+    displaySpecFiles(res.specFiles);
     displayStatesStat(res.initialStatesStat);
     displayCoverage(res.coverageStat);
     displayMessages(res.warnings, 'warnings', 'warnings-list', false);
@@ -138,6 +139,19 @@ function displayStatus(result) {
         elStatusDetails.innerText = result.statusDetails;
     } else {
         elStatusDetails.classList.add('hidden');
+    }
+}
+
+function displaySpecFiles(specFiles) {
+    const elSpecFiles = document.getElementById('spec-files');
+    if (specFiles) {
+        const elTlaFileName = document.getElementById('tla-file-name');
+        const elCfgFileName = document.getElementById('cfg-file-name');
+        elTlaFileName.innerText = specFiles.tlaFileName;
+        elCfgFileName.innerText = specFiles.cfgFileName;
+        elSpecFiles.classList.remove('hidden');
+    } else {
+        elSpecFiles.classList.add('hidden');
     }
 }
 

--- a/resources/check-result-view.js
+++ b/resources/check-result-view.js
@@ -78,9 +78,9 @@ function stopProcess() {
     });
 }
 
-function repeatCheck() {
+function runCheckAgain() {
     vscode.postMessage({
-        command: 'repeat'
+        command: 'runAgain'
     });
 }
 
@@ -144,21 +144,20 @@ function displayStatus(result) {
 function displayStatusHeader(showActions, stillRunning) {
     const elActions = document.getElementById('actions');
     const elShowOutput = document.getElementById('act-show-output');
-    const elRepeat = document.getElementById('act-repeat');
+    const elRunAgain = document.getElementById('act-run-again');
     if (showActions) {
         elActions.classList.remove('hidden');
         elShowOutput.onclick = () => showTlcOutput();
     } else {
         elActions.classList.add('hidden');
         delete elShowOutput.onclick;
-        delete elRepeat.onclick;
     }
     if (stillRunning) {
-        delete elRepeat.onclick;
-        elRepeat.classList.add('hidden');
+        delete elRunAgain.onclick;
+        elRunAgain.classList.add('hidden');
     } else {
-        elRepeat.onclick = () => repeatCheck();
-        elRepeat.classList.remove('hidden');
+        elRunAgain.onclick = () => runCheckAgain();
+        elRunAgain.classList.remove('hidden');
     }
 }
 

--- a/src/checkResultView.ts
+++ b/src/checkResultView.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { ModelCheckResult, ModelCheckResultSource } from './model/check';
+import { ModelCheckResult, ModelCheckResultSource, SpecFiles } from './model/check';
 import { CMD_CHECK_MODEL_STOP, CMD_SHOW_TLC_OUTPUT, CMD_CHECK_MODEL_RUN_AGAIN } from './commands/checkModel';
 
 // Cached HTML template for the WebView
@@ -101,16 +101,16 @@ function ensurePanelBody(extContext: vscode.ExtensionContext) {
     if (!viewPanel) {
         return;
     }
-    const resourcesDiskPath = vscode.Uri.file(
-        path.join(extContext.extensionPath, 'resources')
-    );
-    const resourcesPath = viewPanel.webview.asWebviewUri(resourcesDiskPath);
     if (!viewHtml) {
+        const resourcesDiskPath = vscode.Uri.file(
+            path.join(extContext.extensionPath, 'resources')
+        );
+        const resourcesPath = viewPanel.webview.asWebviewUri(resourcesDiskPath);
         viewHtml = fs.readFileSync(path.join(extContext.extensionPath, 'resources', 'check-result-view.html'), 'utf8');
+        viewHtml = viewHtml
+            .replace(/\${cspSource}/g, viewPanel.webview.cspSource)
+            .replace(/\${resourcesPath}/g, String(resourcesPath));
     }
-    viewHtml = viewHtml
-        .replace(/\${cspSource}/g, viewPanel.webview.cspSource)
-        .replace(/\${resourcesPath}/g, String(resourcesPath));
     viewPanel.webview.html = viewHtml;
 }
 

--- a/src/checkResultView.ts
+++ b/src/checkResultView.ts
@@ -2,12 +2,11 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ModelCheckResult, ModelCheckResultSource } from './model/check';
-import { CMD_CHECK_MODEL_STOP, CMD_SHOW_TLC_OUTPUT, CMD_CHECK_MODEL_REPEAT } from './commands/checkModel';
+import { CMD_CHECK_MODEL_STOP, CMD_SHOW_TLC_OUTPUT, CMD_CHECK_MODEL_RUN_AGAIN } from './commands/checkModel';
 
 // Cached HTML template for the WebView
 let viewHtml: string | undefined;
 let viewPanel: vscode.WebviewPanel | undefined;
-let missing: boolean;
 let currentSource: ModelCheckResultSource | undefined;
 let lastProcessCheckResult: ModelCheckResult | undefined;   // Only results with source=process go here
 let lastCheckResult: ModelCheckResult | undefined;          // The last known check result, no matter what its source is
@@ -18,9 +17,6 @@ export function updateCheckResultView(checkResult: ModelCheckResult) {
             viewPanel.webview.postMessage({
                 checkResult: checkResult
             });
-            missing = false;
-        } else {
-            missing = true;
         }
     }
     lastCheckResult = checkResult;
@@ -84,8 +80,8 @@ function createNewPanel() {
             vscode.commands.executeCommand(CMD_CHECK_MODEL_STOP);
         } else if (message.command === 'showTlcOutput') {
             vscode.commands.executeCommand(CMD_SHOW_TLC_OUTPUT);
-        } else if (message.command === 'repeat') {
-            vscode.commands.executeCommand(CMD_CHECK_MODEL_REPEAT);
+        } else if (message.command === 'runAgain') {
+            vscode.commands.executeCommand(CMD_CHECK_MODEL_RUN_AGAIN);
         } else if (message.command === 'openFile') {
             // `One` is used here because at the moment, VSCode doesn't provide API
             // for revealing existing document, so we're speculating here to reduce open documents duplication.

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -12,13 +12,13 @@ import { ModelCheckResultSource, ModelCheckResult } from '../model/check';
 import { ToolOutputChannel } from '../outputChannels';
 
 export const CMD_CHECK_MODEL_RUN = 'tlaplus.model.check.run';
-export const CMD_CHECK_MODEL_REPEAT = 'tlaplus.model.check.repeat';
+export const CMD_CHECK_MODEL_RUN_AGAIN = 'tlaplus.model.check.runAgain';
 export const CMD_CHECK_MODEL_CUSTOM_RUN = 'tlaplus.model.check.customRun';
 export const CMD_CHECK_MODEL_STOP = 'tlaplus.model.check.stop';
 export const CMD_CHECK_MODEL_DISPLAY = 'tlaplus.model.check.display';
 export const CMD_SHOW_TLC_OUTPUT = 'tlaplus.showTlcOutput';
 export const CTX_TLC_RUNNING = 'tlaplus.tlc.isRunning';
-export const CTX_TLC_CAN_REPEAT = 'tlaplus.tlc.canRepeat';
+export const CTX_TLC_CAN_RUN_AGAIN = 'tlaplus.tlc.canRunAgain';
 
 const CFG_CREATE_OUT_FILES = 'tlaplus.tlc.modelChecker.createOutFiles';
 const TEMPLATE_CFG_PATH = path.resolve(__dirname, '../../../tools/template.cfg');
@@ -58,12 +58,12 @@ export async function checkModel(
     doCheckModel(specFiles, false, extContext, diagnostic);
 }
 
-export async function repeatLastCheck(
+export async function runLastCheckAgain(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext
 ) {
     if (!lastCheckFiles) {
-        vscode.window.showWarningMessage('No check to repeat');
+        vscode.window.showWarningMessage('No last check to run');
         return;
     }
     if (!canRunTlc(extContext)) {
@@ -165,7 +165,7 @@ export async function doCheckModel(
 ): Promise<ModelCheckResult | undefined> {
     try {
         lastCheckFiles = specFiles;
-        vscode.commands.executeCommand('setContext', CTX_TLC_CAN_REPEAT, true);
+        vscode.commands.executeCommand('setContext', CTX_TLC_CAN_RUN_AGAIN, true);
         updateStatusBarItem(true);
         const procInfo = await runTlc(specFiles.tlaFilePath, path.basename(specFiles.cfgFilePath));
         outChannel.bindTo(procInfo);

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -8,7 +8,7 @@ import { applyDCollection } from '../diagnostic';
 import { ChildProcess } from 'child_process';
 import { saveStreamToFile } from '../outputSaver';
 import { replaceExtension, LANG_TLAPLUS, LANG_TLAPLUS_CFG, listFiles, exists } from '../common';
-import { ModelCheckResultSource, ModelCheckResult } from '../model/check';
+import { ModelCheckResultSource, ModelCheckResult, SpecFiles } from '../model/check';
 import { ToolOutputChannel } from '../outputChannels';
 
 export const CMD_CHECK_MODEL_RUN = 'tlaplus.model.check.run';
@@ -30,13 +30,6 @@ const outChannel = new ToolOutputChannel('TLC', mapTlcOutputLine);
 
 class CheckResultHolder {
     checkResult: ModelCheckResult | undefined;
-}
-
-export class SpecFiles {
-    constructor(
-        readonly tlaFilePath: string,
-        readonly cfgFilePath: string
-    ) {}
 }
 
 /**
@@ -182,7 +175,7 @@ export async function doCheckModel(
         const stdoutParser = new TlcModelCheckerStdoutParser(
             ModelCheckResultSource.Process,
             checkProcess.stdout,
-            specFiles.tlaFilePath,
+            specFiles,
             true,
             (checkResult) => {
                 resultHolder.checkResult = checkResult;

--- a/src/commands/evaluateExpression.ts
+++ b/src/commands/evaluateExpression.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { replaceExtension, deleteDir, readFile, exists } from '../common';
-import { SpecFiles, getEditorIfCanRunTlc, doCheckModel } from './checkModel';
+import { getEditorIfCanRunTlc, doCheckModel } from './checkModel';
 import { createCustomModel } from './customModel';
 import { ToolOutputChannel } from '../outputChannels';
-import { ModelCheckResult, CheckState, SequenceValue, Value, OutputLine } from '../model/check';
+import { ModelCheckResult, CheckState, SequenceValue, Value, OutputLine, SpecFiles } from '../model/check';
 import { parseVariableValue } from '../parsers/tlcValues';
 
 export const CMD_EVALUATE_SELECTION = 'tlaplus.evaluateSelection';

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { CMD_CHECK_MODEL_RUN, CMD_CHECK_MODEL_STOP, CMD_CHECK_MODEL_DISPLAY, CMD_SHOW_TLC_OUTPUT,
     CMD_CHECK_MODEL_CUSTOM_RUN, checkModel, displayModelChecking, stopModelChecking,
-    showTlcOutput, checkModelCustom, CMD_CHECK_MODEL_REPEAT, repeatLastCheck} from './commands/checkModel';
+    showTlcOutput, checkModelCustom, CMD_CHECK_MODEL_RUN_AGAIN, runLastCheckAgain} from './commands/checkModel';
 import { CMD_EVALUATE_SELECTION, evaluateSelection, CMD_EVALUATE_EXPRESSION,
     evaluateExpression } from './commands/evaluateExpression';
 import { parseModule, CMD_PARSE_MODULE } from './commands/parseModule';
@@ -48,8 +48,8 @@ export function activate(context: vscode.ExtensionContext) {
             CMD_CHECK_MODEL_RUN,
             (uri) => checkModel(uri, diagnostic, context)),
         vscode.commands.registerCommand(
-            CMD_CHECK_MODEL_REPEAT,
-            () => repeatLastCheck(diagnostic, context)),
+            CMD_CHECK_MODEL_RUN_AGAIN,
+            () => runLastCheckAgain(diagnostic, context)),
         vscode.commands.registerCommand(
             CMD_CHECK_MODEL_CUSTOM_RUN,
             () => checkModelCustom(diagnostic, context)),

--- a/src/model/check.ts
+++ b/src/model/check.ts
@@ -1,4 +1,5 @@
 import { Range, Position } from 'vscode';
+import * as path from 'path';
 import { DCollection } from '../diagnostic';
 import { isNumber } from 'util';
 import { Moment } from 'moment';
@@ -415,6 +416,19 @@ export enum ModelCheckResultSource {
     OutFile     // The result comes from a .out file
 }
 
+export class SpecFiles {
+    readonly tlaFileName: string;
+    readonly cfgFileName: string;
+
+    constructor(
+        readonly tlaFilePath: string,
+        readonly cfgFilePath: string
+    ) {
+        this.tlaFileName = path.basename(tlaFilePath);
+        this.cfgFileName = path.basename(cfgFilePath);
+    }
+}
+
 /**
  * Represents the state of a TLA model checking process.
  */
@@ -428,6 +442,7 @@ export class ModelCheckResult {
 
     constructor(
         readonly source: ModelCheckResultSource,
+        readonly specFiles: SpecFiles | unknown,
         readonly showFullOutput: boolean,
         readonly state: CheckState,
         readonly status: CheckStatus,
@@ -467,7 +482,7 @@ export class ModelCheckResult {
 
     static createEmpty(source: ModelCheckResultSource): ModelCheckResult {
         return new ModelCheckResult(
-            source, false, CheckState.Running, CheckStatus.Starting, undefined, [], [], [], [],
+            source, undefined, false, CheckState.Running, CheckStatus.Starting, undefined, [], [], [], [],
             undefined, undefined, undefined, undefined, 0, undefined, []);
     }
 

--- a/src/parsers/tlc.ts
+++ b/src/parsers/tlc.ts
@@ -4,7 +4,8 @@ import { Readable } from 'stream';
 import { clearTimeout } from 'timers';
 import { CheckStatus, ModelCheckResult, InitialStateStatItem, CoverageItem, MessageLine, MessageSpan, ErrorTraceItem,
     CheckState, OutputLine, StructureValue, findChanges, ModelCheckResultSource, WarningInfo,
-    ErrorInfo } from '../model/check';
+    ErrorInfo,
+    SpecFiles} from '../model/check';
 import { ProcessOutputHandler } from '../outputHandler';
 import { parseVariableValue } from './tlcValues';
 import { SanyData, SanyStdoutParser } from './sany';
@@ -32,15 +33,15 @@ export class TlcModelCheckerStdoutParser extends ProcessOutputHandler<DCollectio
     constructor(
         source: ModelCheckResultSource,
         stdout: Readable | string[],
-        tlaFilePath: string | undefined,
+        specFiles: SpecFiles | undefined,
         showFullOutput: boolean,
         private handler: (checkResult: ModelCheckResult) => void
     ) {
         super(stdout, new DCollection());
         this.handler = handler;
-        this.checkResultBuilder = new ModelCheckResultBuilder(source, showFullOutput);
-        if (tlaFilePath) {
-            this.result.addFilePath(tlaFilePath);
+        this.checkResultBuilder = new ModelCheckResultBuilder(source, specFiles, showFullOutput);
+        if (specFiles) {
+            this.result.addFilePath(specFiles.tlaFilePath);
         }
     }
 
@@ -186,6 +187,7 @@ class ModelCheckResultBuilder {
 
     constructor(
         private source: ModelCheckResultSource,
+        private specFiles: SpecFiles | undefined,
         private showFullOutput: boolean
     ) {}
 
@@ -234,6 +236,7 @@ class ModelCheckResultBuilder {
     build(): ModelCheckResult {
         return new ModelCheckResult(
             this.source,
+            this.specFiles,
             this.showFullOutput,
             this.state,
             this.status,

--- a/tests/suite/shortcuts.ts
+++ b/tests/suite/shortcuts.ts
@@ -132,6 +132,7 @@ export class CheckResultBuilder {
     build(): ModelCheckResult {
         return new ModelCheckResult(
             ModelCheckResultSource.OutFile,
+            undefined,
             false,
             this.checkState,
             this.checkStatus,


### PR DESCRIPTION
- Rename "Repeat" to "Check again"
- Display spec and model file names on check result panel

ref #115
