### PR TITLE
SANY messages parsing improvements

### DIFF
--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -61,7 +61,9 @@ export function applyDCollection(dCol: DCollection, dc: vscode.DiagnosticCollect
  */
 export function addDiagnostics(from: DCollection, to: DCollection): void {
     from.getModules().forEach((modPath) => to.addFilePath(modPath));
-    from.getMessages().forEach((msg) => to.addMessage(msg.filePath, msg.diagnostic.range, msg.diagnostic.message));
+    from.getMessages().forEach((msg) =>
+        to.addMessage(msg.filePath, msg.diagnostic.range, msg.diagnostic.message, msg.diagnostic.severity)
+    );
 }
 
 /**

--- a/src/parsers/tlc.ts
+++ b/src/parsers/tlc.ts
@@ -1,4 +1,4 @@
-import { Range, Position, window } from 'vscode';
+import { Range, Position, window, DiagnosticSeverity } from 'vscode';
 import * as moment from 'moment/moment';
 import { Readable } from 'stream';
 import { clearTimeout } from 'timers';
@@ -422,8 +422,12 @@ class ModelCheckResultBuilder {
         this.sanyData = sany.readAllSync();
         // Display SANY error messages as model checking errors
         this.sanyData.dCollection.getMessages().forEach(diag => {
-            const errMessage = MessageLine.fromText(diag.diagnostic.message);
-            this.errors.push(new ErrorInfo([errMessage], []));
+            const message = MessageLine.fromText(diag.diagnostic.message);
+            if (diag.diagnostic.severity === DiagnosticSeverity.Warning) {
+                this.warnings.push(new WarningInfo([message]));
+            } else {
+                this.errors.push(new ErrorInfo([message], []));
+            }
         });
     }
 

--- a/tests/fixtures/parsers/tlc/sany-warning.out
+++ b/tests/fixtures/parsers/tlc/sany-warning.out
@@ -1,0 +1,25 @@
+@!@!@STARTMSG 2262:0 @!@!@
+TLC2 Version 2.14 of 10 July 2019 (rev: 0cae24f)
+@!@!@ENDMSG 2262 @!@!@
+@!@!@STARTMSG 2187:0 @!@!@
+Running breadth-first search Model-Checking with fp 86 and seed -5126315020031287108.
+@!@!@ENDMSG 2187 @!@!@
+@!@!@STARTMSG 2220:0 @!@!@
+Starting SANY...
+@!@!@ENDMSG 2220 @!@!@
+Parsing file /Users/alice/TLA/foo.tla
+Semantic processing of module foo
+
+*** Warnings: 1
+line 5, col 8 to line 5, col 8 of module foo
+Multiple declarations of operator `a'.
+
+@!@!@STARTMSG 2219:0 @!@!@
+SANY finished.
+@!@!@ENDMSG 2219 @!@!@
+@!@!@STARTMSG 2185:0 @!@!@
+Starting... (2019-08-17 02:04:44)
+@!@!@ENDMSG 2185 @!@!@
+@!@!@STARTMSG 2186:0 @!@!@
+Finished in 380ms at (2019-08-17 02:04:44)
+@!@!@ENDMSG 2186 @!@!@

--- a/tests/suite/parsers/sany.test.ts
+++ b/tests/suite/parsers/sany.test.ts
@@ -308,16 +308,14 @@ suite('SANY Output Parser Test Suite', () => {
             ]));
     });
 
-    test ('CAN IMPROVE: Captures warnings', () => {
+    test ('Captures warnings', () => {
         const stdout = [
             `Parsing file ${ROOT_PATH}`,
             `Semantic processing of module ${ROOT_NAME}`,
             'Semantic errors:',
             '*** Warnings: 1',
             `line 24, col 10 to line 24, col 25 of module ${ROOT_NAME}`,
-            'Multiple declarations or definitions for symbol FooConst.',
-            // The following line is not captured, but it would be cool to add it to the warning text
-            `This duplicates the one at line 3, col 10 to line 3, col 25 of module ${ROOT_NAME}.`
+            'Multiple declarations or definitions for symbol FooConst.'
         ].join('\n');
         assertOutput(
             stdout,
@@ -325,6 +323,63 @@ suite('SANY Output Parser Test Suite', () => {
                 diagWarning(
                     range(23, 9, 23, 25),
                     'Multiple declarations or definitions for symbol FooConst.'
+                )
+            ]));
+    });
+
+    test ('Captures multi-line messages', () => {
+        const stdout = [
+            `Parsing file ${ROOT_PATH}`,
+            `Semantic processing of module ${ROOT_NAME}`,
+            'Semantic errors:',
+            '*** Warnings: 1',
+            `line 24, col 10 to line 24, col 25 of module ${ROOT_NAME}`,
+            'Multiple declarations or definitions for symbol FooConst.',
+            `This duplicates the one at line 3, col 10 to line 3, col 25 of module ${ROOT_NAME}.`,
+            `line 31, col 8 to line 31, col 20 of module ${ROOT_NAME}`,
+            'Multiple declarations or definitions for symbol BarConst.',
+            `This duplicates the one at line 4, col 10 to line 4, col 25 of module ${ROOT_NAME}.`,
+        ].join('\n');
+        assertOutput(
+            stdout,
+            expectDiag(ROOT_PATH, [
+                diagWarning(
+                    range(23, 9, 23, 25),
+                    'Multiple declarations or definitions for symbol FooConst.\n'
+                        + `This duplicates the one at line 3, col 10 to line 3, col 25 of module ${ROOT_NAME}.`
+                ),
+                diagWarning(
+                    range(30, 7, 30, 20),
+                    'Multiple declarations or definitions for symbol BarConst.\n'
+                        + `This duplicates the one at line 4, col 10 to line 4, col 25 of module ${ROOT_NAME}.`
+                )
+            ]));
+    });
+
+    test ('Captures both warnings and errors from one output', () => {
+        const stdout = [
+            `Parsing file ${ROOT_PATH}`,
+            `Semantic processing of module ${ROOT_NAME}`,
+            'Semantic errors:',
+            '*** Errors: 1',
+            `line 13, col 1 to line 13, col 26 of module ${ROOT_NAME}`,
+            'Operator FooBar already defined or declared.',
+            '*** Warnings: 1',
+            `line 13, col 1 to line 13, col 26 of module ${ROOT_NAME}`,
+            'Multiple declarations or definitions for symbol FooBar.',
+            `This duplicates the one at line 11, col 1 to line 11, col 26 of module ${ROOT_NAME}.`
+        ].join('\n');
+        assertOutput(
+            stdout,
+            expectDiag(ROOT_PATH, [
+                diagError(
+                    range(12, 0, 12, 26),
+                    'Operator FooBar already defined or declared.'
+                ),
+                diagWarning(
+                    range(12, 0, 12, 26),
+                    'Multiple declarations or definitions for symbol FooBar.\n'
+                        + `This duplicates the one at line 11, col 1 to line 11, col 26 of module ${ROOT_NAME}.`
                 )
             ]));
     });

--- a/tests/suite/parsers/tlc.test.ts
+++ b/tests/suite/parsers/tlc.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import * as fs from 'fs';
+import { DiagnosticSeverity } from 'vscode';
 import { before } from 'mocha';
 import { PassThrough } from 'stream';
 import { ModelCheckResult, CheckState, CheckStatus, ModelCheckResultSource, Value,
@@ -140,9 +141,33 @@ suite('TLC Output Parser Test Suite', () => {
                 .setStartDateTime('2019-08-17 02:04:44')
                 .setEndDateTime('2019-08-17 02:04:44')
                 .setDuration(380)
-                .addDColMessage(TEST_SPEC_FILES.tlaFilePath, range(4, 7, 4, 8), "Unknown operator: `a'.")
+                .addDColMessage(
+                    TEST_SPEC_FILES.tlaFilePath,
+                    range(4, 7, 4, 8),
+                    "Unknown operator: `a'.",
+                    DiagnosticSeverity.Error
+                )
                 .addError([message("Unknown operator: `a'.")])
                 .addError([message('Parsing or semantic analysis failed.')])
+                .build()
+        );
+    });
+
+    test('Captures SANY warnings', () => {
+        return assertOutput('sany-warning.out', TEST_SPEC_FILES,
+            new CheckResultBuilder('sany-warning.out', CheckState.Error, CheckStatus.Finished)
+                .setProcessInfo('Running breadth-first search Model-Checking with fp 86 and seed -5126315020031287108.')
+                .addDColFilePath(TEST_SPEC_FILES.tlaFilePath)
+                .setStartDateTime('2019-08-17 02:04:44')
+                .setEndDateTime('2019-08-17 02:04:44')
+                .setDuration(380)
+                .addDColMessage(
+                    TEST_SPEC_FILES.tlaFilePath,
+                    range(4, 7, 4, 8),
+                    "Multiple declarations of operator `a'.",
+                    DiagnosticSeverity.Warning
+                )
+                .addWarning([message("Multiple declarations of operator `a'.")])
                 .build()
         );
     });

--- a/tests/suite/shortcuts.ts
+++ b/tests/suite/shortcuts.ts
@@ -222,9 +222,14 @@ export class CheckResultBuilder {
         return this;
     }
 
-    addDColMessage(filePath: string, range: vscode.Range, text: string): CheckResultBuilder {
+    addDColMessage(
+        filePath: string,
+        range: vscode.Range,
+        text: string,
+        severity: vscode.DiagnosticSeverity
+    ): CheckResultBuilder {
         this.ensureSanyMessages();
-        this.sanyMessages?.addMessage(filePath, range, text);
+        this.sanyMessages?.addMessage(filePath, range, text, severity);
         return this;
     }
 


### PR DESCRIPTION
* Parse multi-line SANY messages
* More robust separation of SANY errors and warnings
* Display SANY warnings as warnings on the Check View Result panel, not as errors

ref #179