### PR TITLE
Fix monolith spec error location

### DIFF
--- a/src/commands/parseModule.ts
+++ b/src/commands/parseModule.ts
@@ -51,28 +51,6 @@ async function transpilePlusCal(fileUri: vscode.Uri): Promise<DCollection> {
     return stdoutParser.readAll();
 }
 
-async function adaptMonolithMessages(sanyResult : SanyData) {
-    const invertedModulePaths = new Map(Array.from(sanyResult.modulePaths, (i) => i.reverse() as [string, string]));
-    for (const [filePath, monolithFilePath] of sanyResult.filePathToMonolithFilePath) {
-        const text = (await vscode.workspace.openTextDocument(monolithFilePath)).getText();
-        const specName = invertedModulePaths.get(filePath);
-        text.split('\n').forEach(function (line, number) {
-            if (new RegExp(`-----*\\s*MODULE\\s+${specName}\\s*----*`).exec(line)) {
-                sanyResult.dCollection.getMessages().filter(m => m.filePath === filePath).forEach(message => {
-                    const oldRange = message.diagnostic.range;
-                    // Remove message so it does not appear duplicated in the output.
-                    sanyResult.dCollection.removeMessage(message);
-                    sanyResult.dCollection.addMessage(
-                        monolithFilePath, 
-                        new vscode.Range(oldRange.start.line + number, oldRange.start.character, oldRange.end.line + number, oldRange.end.character),
-                        message.diagnostic.message,
-                        message.diagnostic.severity);
-                })
-            } 
-        });
-    }
-}
-
 /**
  * Parses the resulting TLA+ spec.
  */
@@ -80,9 +58,5 @@ async function parseSpec(fileUri: vscode.Uri): Promise<SanyData> {
     const procInfo = await runSany(fileUri.fsPath);
     sanyOutChannel.bindTo(procInfo);
     const stdoutParser = new SanyStdoutParser(procInfo.process.stdout);
-    const sanyResult = await stdoutParser.readAll();
-    // Adapt monolith error locations.
-    // It modifies the Sany result adding the module offset for in the monolith spec.
-    await adaptMonolithMessages(sanyResult);
-    return sanyResult;
+    return stdoutParser.readAll();
 }

--- a/src/commands/parseModule.ts
+++ b/src/commands/parseModule.ts
@@ -51,6 +51,28 @@ async function transpilePlusCal(fileUri: vscode.Uri): Promise<DCollection> {
     return stdoutParser.readAll();
 }
 
+async function adaptMonolithMessages(sanyResult : SanyData) {
+    const invertedModulePaths = new Map(Array.from(sanyResult.modulePaths, (i) => i.reverse() as [string, string]));
+    for (const [filePath, monolithFilePath] of sanyResult.filePathToMonolithFilePath) {
+        const text = (await vscode.workspace.openTextDocument(monolithFilePath)).getText();;
+        const specName = invertedModulePaths.get(filePath);
+        text.split('\n').forEach(function (line, number) {
+            if (new RegExp("-----*\\s*MODULE\\s+" + specName + "\\s*----*").exec(line)) {
+                sanyResult.dCollection.getMessages().filter(m => m.filePath == filePath).forEach(message => {
+                    const oldRange = message.diagnostic.range;
+                    // Remove message so it does not appear duplicated in the output.
+                    sanyResult.dCollection.removeMessage(message);
+                    sanyResult.dCollection.addMessage(
+                        monolithFilePath, 
+                        new vscode.Range(oldRange.start.line + number, oldRange.start.character, oldRange.end.line + number, oldRange.end.character),
+                        message.diagnostic.message,
+                        message.diagnostic.severity);
+                })
+            } 
+        });
+    }
+}
+
 /**
  * Parses the resulting TLA+ spec.
  */
@@ -58,5 +80,9 @@ async function parseSpec(fileUri: vscode.Uri): Promise<SanyData> {
     const procInfo = await runSany(fileUri.fsPath);
     sanyOutChannel.bindTo(procInfo);
     const stdoutParser = new SanyStdoutParser(procInfo.process.stdout);
-    return stdoutParser.readAll();
+    const sanyResult = await stdoutParser.readAll();
+    // Adapt monolith error locations.
+    // It modifies the Sany result adding the module offset for in the monolith spec.
+    await adaptMonolithMessages(sanyResult);
+    return sanyResult;
 }

--- a/src/commands/parseModule.ts
+++ b/src/commands/parseModule.ts
@@ -54,11 +54,11 @@ async function transpilePlusCal(fileUri: vscode.Uri): Promise<DCollection> {
 async function adaptMonolithMessages(sanyResult : SanyData) {
     const invertedModulePaths = new Map(Array.from(sanyResult.modulePaths, (i) => i.reverse() as [string, string]));
     for (const [filePath, monolithFilePath] of sanyResult.filePathToMonolithFilePath) {
-        const text = (await vscode.workspace.openTextDocument(monolithFilePath)).getText();;
+        const text = (await vscode.workspace.openTextDocument(monolithFilePath)).getText();
         const specName = invertedModulePaths.get(filePath);
         text.split('\n').forEach(function (line, number) {
-            if (new RegExp("-----*\\s*MODULE\\s+" + specName + "\\s*----*").exec(line)) {
-                sanyResult.dCollection.getMessages().filter(m => m.filePath == filePath).forEach(message => {
+            if (new RegExp(`-----*\\s*MODULE\\s+${specName}\\s*----*`).exec(line)) {
+                sanyResult.dCollection.getMessages().filter(m => m.filePath === filePath).forEach(message => {
                     const oldRange = message.diagnostic.range;
                     // Remove message so it does not appear duplicated in the output.
                     sanyResult.dCollection.removeMessage(message);

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -6,7 +6,7 @@ import { pathToModuleName, pathToUri } from './common';
  */
 export class DCollection {
     private readonly modules: Map<string, string> = new Map();   // Map of checked modules names to file paths
-    private readonly messages: DMessage[] = [];                  // Collection of diagnostic messages from the check run
+    private messages: DMessage[] = [];                  // Collection of diagnostic messages from the check run
 
     public getModules(): ReadonlyMap<string, string> {
         return this.modules;
@@ -28,6 +28,12 @@ export class DCollection {
     ): void {
         this.messages.push(new DMessage(filePath, range, text, severity));
         this.addFilePath(filePath);
+    }
+
+    public removeMessage(
+        dMessage: DMessage,
+    ): void {
+        this.messages = this.messages.filter(v => v != dMessage);
     }
 
     public addAll(src: DCollection): void {

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -33,7 +33,7 @@ export class DCollection {
     public removeMessage(
         dMessage: DMessage,
     ): void {
-        this.messages = this.messages.filter(v => v != dMessage);
+        this.messages = this.messages.filter(v => v !== dMessage);
     }
 
     public addAll(src: DCollection): void {

--- a/src/parsers/sany.ts
+++ b/src/parsers/sany.ts
@@ -102,7 +102,7 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
             const text = this.getFileContents(monolithFilePath);
             const specName = invertedModulePaths.get(filePath);
             const moduleHeaderRegex = new RegExp(`^\\s*-{4,}\\s*(MODULE)\\s*${specName}\\s*-{4,}`);
-            text.split('\n').forEach(function(line, number) {
+            text.split('\n').every(function(line, number) {
                 if (moduleHeaderRegex.test(line)) {
                     sanyData.dCollection.getMessages().filter(m => m.filePath === filePath).forEach(message => {
                         const oldRange = message.diagnostic.range;
@@ -118,8 +118,9 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
                             message.diagnostic.message,
                             message.diagnostic.severity);
                     });
-                    return;
+                    return false; // Break out from `every`.
                 }
+                return true;
             });
         }
     }

--- a/src/parsers/sany.ts
+++ b/src/parsers/sany.ts
@@ -64,13 +64,7 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
         } else if (line.startsWith('*** Warnings:')) {
             newBlockType = OutBlockType.Warnings;
         } else if (line.startsWith('Fatal errors while parsing TLA+ spec')) {
-            const curMod = line.substring(45).split('\.')[0];
-            const actualFilePath = this.result.modulePaths.get(curMod);
-            // If current file path differs from the actual file path, it means we are in a monolith spec.
-            // Monolith specs are TLA files which have multiple modules inline.
-            if (this.curFilePath && actualFilePath && actualFilePath != this.curFilePath) {
-                this.result.filePathToMonolithFilePath.set(this.curFilePath, actualFilePath);
-            }
+            this.tryAddMonolithSpec(line);
             newBlockType = OutBlockType.ParseError;
             newErrMessage = line.trim();
         } else if (line.startsWith('Residual stack trace follows:')) {
@@ -86,6 +80,16 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
             return;
         }
         this.tryParseOutLine(line);
+    }
+
+    private tryAddMonolithSpec(line: string) {
+        const curMod = line.substring(45).split('\.')[0];
+        const actualFilePath = this.result.modulePaths.get(curMod);
+        // If current file path differs from the actual file path, it means we are in a monolith spec.
+        // Monolith specs are TLA files which have multiple modules inline.
+        if (this.curFilePath && actualFilePath && actualFilePath !== this.curFilePath) {
+            this.result.filePathToMonolithFilePath.set(this.curFilePath, actualFilePath);
+        }
     }
 
     private tryParseOutLine(line: string) {

--- a/src/parsers/sany.ts
+++ b/src/parsers/sany.ts
@@ -31,7 +31,8 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
     errRange: vscode.Range | undefined;
     errMessage: string | undefined;
     pendingAbortMessage = false;
-    public getFileContents = (filePath : string) => readFileSync(filePath).toString(); // this should be set only at tests
+    public getFileContents =
+        (filePath : string) : string => readFileSync(filePath).toString(); // this should be set only at tests
 
     constructor(source: Readable | string[] | null) {
         super(source, new SanyData());
@@ -85,7 +86,7 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
     }
 
     private tryAddMonolithSpec(line: string) {
-        const curMod = line.substring(45).split('\.')[0];
+        const curMod = line.substring(45).split('.')[0];
         const actualFilePath = this.result.modulePaths.get(curMod);
         const sanyData = this.result;
         // If current file path differs from the actual file path, it means we are in a monolith spec.
@@ -95,22 +96,28 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
             const monolithFilePath = actualFilePath;
             // Adapt monolith error locations.
             // It modifies the Sany result adding the module offset in the monolith spec.
-            const invertedModulePaths = new Map(Array.from(sanyData.modulePaths, (i) => i.reverse() as [string, string]));
+            const invertedModulePaths = new Map(
+                Array.from(sanyData.modulePaths, (i) => i.reverse() as [string, string])
+            );
             const text = this.getFileContents(monolithFilePath);
             const specName = invertedModulePaths.get(filePath);
             const moduleHeaderRegex = new RegExp(`^\\s*-{4,}\\s*(MODULE)\\s*${specName}\\s*-{4,}`);
-            text.split('\n').forEach(function (line, number) {
-                if (moduleHeaderRegex.test(line)) {                
+            text.split('\n').forEach(function(line, number) {
+                if (moduleHeaderRegex.test(line)) {
                     sanyData.dCollection.getMessages().filter(m => m.filePath === filePath).forEach(message => {
                         const oldRange = message.diagnostic.range;
                         // Remove message so it does not appear duplicated in the output.
                         sanyData.dCollection.removeMessage(message);
                         sanyData.dCollection.addMessage(
                             monolithFilePath,
-                            new vscode.Range(oldRange.start.line + number, oldRange.start.character, oldRange.end.line + number, oldRange.end.character),
+                            new vscode.Range(
+                                oldRange.start.line + number,
+                                oldRange.start.character,
+                                oldRange.end.line + number,
+                                oldRange.end.character),
                             message.diagnostic.message,
                             message.diagnostic.severity);
-                    })
+                    });
                     return;
                 }
             });

--- a/src/parsers/sany.ts
+++ b/src/parsers/sany.ts
@@ -98,8 +98,9 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
             const invertedModulePaths = new Map(Array.from(sanyData.modulePaths, (i) => i.reverse() as [string, string]));
             const text = this.getFileContents(monolithFilePath);
             const specName = invertedModulePaths.get(filePath);
+            const moduleHeaderRegex = new RegExp(`^\\s*-{4,}\\s*(MODULE)\\s*${specName}\\s*-{4,}`);
             text.split('\n').forEach(function (line, number) {
-                if (new RegExp(`-----*\\s*MODULE\\s+${specName}\\s*----*`).exec(line)) {
+                if (moduleHeaderRegex.test(line)) {                
                     sanyData.dCollection.getMessages().filter(m => m.filePath === filePath).forEach(message => {
                         const oldRange = message.diagnostic.range;
                         // Remove message so it does not appear duplicated in the output.
@@ -110,6 +111,7 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
                             message.diagnostic.message,
                             message.diagnostic.severity);
                     })
+                    return;
                 }
             });
         }

--- a/tests/suite/parsers/sany.test.ts
+++ b/tests/suite/parsers/sany.test.ts
@@ -384,7 +384,7 @@ suite('SANY Output Parser Test Suite', () => {
             ]));
     });
 
-    test('Captures monolith spec error', () => {
+    test.only('Captures monolith spec error', () => {
         const stdout = [
             '',
             '****** SANY2 Version 2.1 created 24 February 2014',
@@ -398,12 +398,12 @@ suite('SANY Output Parser Test Suite', () => {
         ].join('\n');
         assertOutputWithFileContents(
             stdout,
-            (i) => "\n\n\n----- MODULE TLC ----",
+            (i) => '\n\n\n----- MODULE TLC ----' ,
             expectDiag(ROOT_PATH, [
-                diagError(range(10, 8, 10, 8), 'Encountered \"tcolor\" at line 8, column 9 and token \"active\"')
+                diagError(range(10, 8, 10, 8), 'Encountered "tcolor" at line 8, column 9 and token "active"')
             ]),
             expectDiag('/private/var/dependencies/TLC.tla', [
-                diagError(range(0, 0, 0, 0), "Fatal errors while parsing TLA+ spec in file foo.tla")
+                diagError(range(0, 0, 0, 0), 'Fatal errors while parsing TLA+ spec in file foo.tla')
             ]));
     });
 
@@ -420,7 +420,8 @@ function assertOutput(out: string, ...expected: Expectation[]) {
     }
 }
 
-function assertOutputWithFileContents(out: string, getFileContents : (filePath : string) => string, ...expected: Expectation[]) {
+function assertOutputWithFileContents(
+    out: string, getFileContents : (filePath : string) => string, ...expected: Expectation[]) {
     const outLines = out.split('\n');
     const parser = new SanyStdoutParser(outLines);
     parser.getFileContents = getFileContents;

--- a/tests/suite/parsers/sany.test.ts
+++ b/tests/suite/parsers/sany.test.ts
@@ -384,7 +384,7 @@ suite('SANY Output Parser Test Suite', () => {
             ]));
     });
 
-    test.only('Captures monolith spec error', () => {
+    test('Captures monolith spec error', () => {
         const stdout = [
             '',
             '****** SANY2 Version 2.1 created 24 February 2014',
@@ -398,7 +398,7 @@ suite('SANY Output Parser Test Suite', () => {
         ].join('\n');
         assertOutputWithFileContents(
             stdout,
-            (i) => "\n\n\n---- MODULE TLC ----",
+            (i) => "\n\n\n----- MODULE TLC ----",
             expectDiag(ROOT_PATH, [
                 diagError(range(10, 8, 10, 8), 'Encountered \"tcolor\" at line 8, column 9 and token \"active\"')
             ]),

--- a/tests/suite/parsers/sany.test.ts
+++ b/tests/suite/parsers/sany.test.ts
@@ -384,7 +384,7 @@ suite('SANY Output Parser Test Suite', () => {
             ]));
     });
 
-    test.only('Captures monolith spec error', () => {
+    test('Captures monolith spec error', () => {
         const stdout = [
             '',
             '****** SANY2 Version 2.1 created 24 February 2014',

--- a/tests/suite/parsers/sany.test.ts
+++ b/tests/suite/parsers/sany.test.ts
@@ -383,11 +383,47 @@ suite('SANY Output Parser Test Suite', () => {
                 )
             ]));
     });
+
+    test.only('Captures monolith spec error', () => {
+        const stdout = [
+            '',
+            '****** SANY2 Version 2.1 created 24 February 2014',
+            '',
+            `Parsing file ${ROOT_PATH}`,
+            'Parsing file /private/var/dependencies/TLC.tla',
+            '***Parse Error***',
+            'Encountered "tcolor" at line 8, column 9 and token "active"',
+            '',
+            `Fatal errors while parsing TLA+ spec in file ${ROOT_NAME}.tla`
+        ].join('\n');
+        assertOutputWithFileContents(
+            stdout,
+            (i) => "\n\n\n---- MODULE TLC ----",
+            expectDiag(ROOT_PATH, [
+                diagError(range(10, 8, 10, 8), 'Encountered \"tcolor\" at line 8, column 9 and token \"active\"')
+            ]),
+            expectDiag('/private/var/dependencies/TLC.tla', [
+                diagError(range(0, 0, 0, 0), "Fatal errors while parsing TLA+ spec in file foo.tla")
+            ]));
+    });
+
 });
 
 function assertOutput(out: string, ...expected: Expectation[]) {
     const outLines = out.split('\n');
     const parser = new SanyStdoutParser(outLines);
+    const sanyData = parser.readAllSync();
+    applyDCollection(sanyData.dCollection, getTlaDiagnostics());
+    for (const exp of expected) {
+        const actDiags = getTlaDiagnostics().get(pathToUri(exp.filePath));
+        assert.deepEqual(actDiags, exp.diagnostics);
+    }
+}
+
+function assertOutputWithFileContents(out: string, getFileContents : (filePath : string) => string, ...expected: Expectation[]) {
+    const outLines = out.split('\n');
+    const parser = new SanyStdoutParser(outLines);
+    parser.getFileContents = getFileContents;
     const sanyData = parser.readAllSync();
     applyDCollection(sanyData.dCollection, getTlaDiagnostics());
     for (const exp of expected) {


### PR DESCRIPTION
Try to address https://github.com/alygin/vscode-tlaplus/issues/185.

To fix the monolith spec error location, I try to analyze the "Fatal
error" message which appears **after** the Sany parse of all the
monolith modules (well, I'm assuming that it will be always like this).

I guess we could create a issue (if not already existent) to expose
structured data (in JSON, EDN or XML) at the CLI output, itself (or
in a separate output file). It's fragile, time consuming and make the 
code too complex having to deal with raw strings.

This is the first time I'm toying with this code, so if you have time to
read, tell me where I could improve so we follow the project best
practices =D

Also, thanks for this awesome extension!!