### PR TITLE
Use extensionPath to resolve resources path for webview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-tlaplus",
-    "version": "1.5.1",
+    "version": "1.5.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -254,7 +254,6 @@
                     "type": "string",
                     "scope": "window",
                     "default": "",
-                    "format": "uri",
                     "description": "Path to Java (8 or higher, 11 is recommended) home directory that should be used to run TLA+ tools.",
                     "maxLength": 1000
                 },

--- a/src/checkResultView.ts
+++ b/src/checkResultView.ts
@@ -46,14 +46,14 @@ function revealCheckResultView(checkResult: ModelCheckResult, extContext: vscode
 
 function doRevealCheckResultView(extContext: vscode.ExtensionContext) {
     if (!viewPanel) {
-        createNewPanel();
+        createNewPanel(extContext);
         ensurePanelBody(extContext);
     } else {
         viewPanel.reveal();
     }
 }
 
-function createNewPanel() {
+function createNewPanel(extContext: vscode.ExtensionContext) {
     const title = 'TLA+ model checking';
     viewPanel = vscode.window.createWebviewPanel(
         'modelChecking',
@@ -61,7 +61,7 @@ function createNewPanel() {
         vscode.ViewColumn.Beside,
         {
             enableScripts: true,
-            localResourceRoots: [vscode.Uri.file(path.resolve(__dirname, '../../resources'))]
+            localResourceRoots: [vscode.Uri.file(path.join(extContext.extensionPath, 'resources'))]
         }
     );
     viewPanel.iconPath = {

--- a/src/checkResultView.ts
+++ b/src/checkResultView.ts
@@ -65,8 +65,8 @@ function createNewPanel(extContext: vscode.ExtensionContext) {
         }
     );
     viewPanel.iconPath = {
-        dark: vscode.Uri.file(path.resolve(__dirname, '../../resources/images/preview-dark.svg')),
-        light: vscode.Uri.file(path.resolve(__dirname, '../../resources/images/preview-light.svg')),
+        dark: vscode.Uri.file(path.join(extContext.extensionPath, 'resources/images/preview-dark.svg')),
+        light: vscode.Uri.file(path.join(extContext.extensionPath, 'resources/images/preview-light.svg')),
     };
     viewPanel.onDidDispose(() => {
         viewPanel = undefined;


### PR DESCRIPTION
It turned out that if the extension was built with Nix, the webview gets a 401 when trying to access any of its resources.

With these lines:

```typescript
log.appendLine(`dirname resolved: ${path.resolve(__dirname, '../../resources')}`);
log.appendLine(`extensionPath resolved: ${path.join(extContext.extensionPath, 'resources')}`);
```

While debugging the extension from vscode, no Nix involved:

```
dirname resolved: /Users/kubukoz/IdeaProjects/vscode-tlaplus/resources
extensionPath resolved: /Users/kubukoz/IdeaProjects/vscode-tlaplus/resources
```

Same path.

With nix and home-manager handling vscode extensions:

```
dirname resolved: /nix/store/i7vk8j8k7iqvmbh9iwjplpry96cdcgp8-vscode-extension-vscode-tlaplus/share/vscode/extensions/alygin.vscode-tlaplus/resources
extensionPath resolved: /Users/kubukoz/.vscode/extensions/alygin.vscode-tlaplus/resources
```

The contents of the files are essentially the same... but:

Nix put the extension sources in `/nix/store/i7vk8j8k7iqvmbh9iwjplpry96cdcgp8-vscode-extension-vscode-tlaplus/share/vscode/extensions/alygin.vscode-tlaplus`, and these are the original ones: with the `${resourcesPath}` placeholder still there.

The result of building the package with Nix is put into `/nix/store/swvbpd1m4cjbdbs50rpqylm8za0ags2x-home-manager-files/.vscode/extensions/alygin.vscode-tlaplus`, which is symlinked in my `~/.vscode/extensions` by home-manager as `alygin.vscode-tlaplus` - and this actually contains the right replacements made in:

```typescript
const resourcesDiskPath = vscode.Uri.file(
    path.join(extContext.extensionPath, 'resources')
);
const resourcesPath = viewPanel.webview.asWebviewUri(resourcesDiskPath);
viewHtml = viewHtmlTemplate
    .replace(/\${cspSource}/g, viewPanel.webview.cspSource)
    .replace(/\${resourcesPath}/g, String(resourcesPath));
```

so I just went and used the same approach here to get the same path. Both (with links resolved) start with `/nix/store`, but are completely unrelated, so it makes sense that the browser wouln't recognize them.

As a bonus, I removed the `uri` format from the Java Home config, as I believe it's incorrect: closes #195.