### PR TITLE
Highlight special symbols within EXCEPT expressions

### DIFF
--- a/languages/tlaplus-grammar.json
+++ b/languages/tlaplus-grammar.json
@@ -63,6 +63,9 @@
         },
         {
             "include": "#primed_operators"
+        },
+        {
+            "include": "#except_vars"
         }
     ],
     "repository": {
@@ -218,6 +221,10 @@
         },
         "primed_operators": {
             "match": "\\b(\\w+')",
+            "name": "variable.name"
+        },
+        "except_vars": {
+            "match": "(?<=EXCEPT.*[^@])(@|!)(?!@)",
             "name": "variable.name"
         }
     }


### PR DESCRIPTION
Add highligting to `@`s and `!`s within EXCEPT one-liners.

ref #200