### PR TITLE
Capture pluscal transpiler errors with a newline before the message

### DIFF
--- a/src/parsers/pluscal.ts
+++ b/src/parsers/pluscal.ts
@@ -59,9 +59,9 @@ export class TranspilerStdoutParser extends ProcessOutputHandler<DCollection> {
             return false;
         }
         // matchers should never be null at this point if this.nextLineIsError is false, but the null check can't
-        // detect that. Instead, we use the matchers_message constant which ensures matchers is not indexed if null.
-        const matchers_message = matchers ? matchers[1] : '';
-        const message = this.nextLineIsError ? line : matchers_message;
+        // detect that. Instead, we use the matchersMessage constant which ensures matchers is not indexed if null.
+        const matchersMessage = matchers ? matchers[1] : '';
+        const message = this.nextLineIsError ? line : matchersMessage;
 
         if (message.startsWith('Beginning of algorithm string --algorithm not found')) {
             // This error means that there's no PlusCal code in file. Just ignore it.

--- a/src/parsers/pluscal.ts
+++ b/src/parsers/pluscal.ts
@@ -73,9 +73,10 @@ export class TranspilerStdoutParser extends ProcessOutputHandler<DCollection> {
             this.nextLineIsError = false;
         }
 
-        // Assume that an empty string message means that the next line is an error. This can happen when the error
-        // string looks like: "Unrecoverable error:\n -- \nProcess proc redefined at line 10, column 1\n".
-        if (message === '') {
+        // Assume that an empty string message that matches the regex means that the next line is an error. This can
+        // happen when the error string looks like:
+        // "Unrecoverable error:\n -- \nProcess proc redefined at line 10, column 1\n".
+        if (message === '' && matchers) {
             this.nextLineIsError = true;
             return true;
         }

--- a/tests/suite/parsers/pluscal.test.ts
+++ b/tests/suite/parsers/pluscal.test.ts
@@ -85,6 +85,29 @@ suite('PlusCal Transpiler Output Parser Test Suite', () => {
                 vscode.DiagnosticSeverity.Error)
         ]);
     });
+
+    test('Captures multiple errors after blank message', () => {
+        const stdout = [
+            'pcal.trans Version 1.11 of 31 December 2020',
+            'Parsing completed.',
+            '',
+            'Unrecoverable error:',
+            ' -- ',
+            'Process proc redefined at line 10, column 1',
+            'Process variable x redefined at line 11, column 11.',
+            'THIS IS NOT CAPTURED at line 10, column 1.',
+        ].join('\n');
+        assertOutput(stdout, '/Users/bob/TLA/err.tla', [
+            new vscode.Diagnostic(
+                new vscode.Range(9, 1, 9, 1),
+                'Process proc redefined',
+                vscode.DiagnosticSeverity.Error),
+            new vscode.Diagnostic(
+                new vscode.Range(10, 11, 10, 11),
+                'Process variable x redefined',
+                vscode.DiagnosticSeverity.Error)
+        ]);
+    });
 });
 
 function assertOutput(out: string, filePath: string, expected: vscode.Diagnostic[]) {

--- a/tests/suite/parsers/pluscal.test.ts
+++ b/tests/suite/parsers/pluscal.test.ts
@@ -68,6 +68,23 @@ suite('PlusCal Transpiler Output Parser Test Suite', () => {
         ].join('\n');
         assertOutput(stdout, '/Users/bob/TLA/err.tla', []);
     });
+
+    test('Captures errors with blank message', () => {
+        const stdout = [
+            'pcal.trans Version 1.11 of 31 December 2020',
+            'Parsing completed.',
+            '',
+            'Unrecoverable error:',
+            ' -- ',
+            'Process proc redefined at line 10, column 1.',
+        ].join('\n');
+        assertOutput(stdout, '/Users/bob/TLA/err.tla', [
+            new vscode.Diagnostic(
+                new vscode.Range(9, 1, 9, 1),
+                'Process proc redefined',
+                vscode.DiagnosticSeverity.Error)
+        ]);
+    });
 });
 
 function assertOutput(out: string, filePath: string, expected: vscode.Diagnostic[]) {


### PR DESCRIPTION
Fixes #205.

The error messages printed out by PcalDebug.java in the tla toolbox can include a newline after the unrecoverable error prefix but before the actual error messages. In particular, it looks like this happens when symbol extraction from the AST (in PcalSymTab() in PcalSymTab.java) fails due to symbol redefinitions. An example transpiler output in this case is:
```
pcal.trans Version 1.11 of 31 December 2020
Parsing completed.

Unrecoverable error:
 --
Process variable x redefined at line 10, column 11
Process variable y redefined at line 10, column 16.
```

Before this PR, the parse module command fails silently when encountering these error messages. This PR updates the parsing to capture each of these error messages for display as shown below. It does this through assuming that whenever an empty error message is found (meaning the regex matches but the capture group picks up nothing from `/^\s+--\s+(.*)$/g`), the following lines, until the error message postfix (`.\n`) is found, should be treated as error messages. 

![image](https://user-images.githubusercontent.com/6043161/111852435-27f8e780-88d4-11eb-9833-8d1622b1b356.png)

There are a few potential concerns I have about this fix in the future. However, it seems to be working well in the cases I tested and passes the test suite. In particular, my concerns are: 

- The error message postfix used by the pluscal transpiler is `.\n`. It seems like it would be easy for an error message to pop up in the future that contains a `.\n`, but is not meant to be the error message postfix.
- I assume that any empty error message that matches the regex means that there are error messages in the following lines. While it seems to hold true for the cases I tested and passes the test suite, it's possible that this could cause an issue in the future. A potential fix could be to modify the error parsing to start after the prefix `Unrecoverable error:\n -- ` is seen, and to end only after the error postfix is seen.