### PR TITLE
Prompt user with TLC options before running

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,6 +271,13 @@
                     "description": "Additional options to pass to PlusCal transpiler.",
                     "maxLength": 1000
                 },
+                "tlaplus.tlc.modelChecker.options": {
+                    "type": "string",
+                    "scope": "window",
+                    "default": "",
+                    "description": "Additional options to pass to TLC.",
+                    "maxLength": 1000
+                },
                 "tlaplus.tlc.modelChecker.createOutFiles": {
                     "type": "boolean",
                     "scope": "window",

--- a/package.json
+++ b/package.json
@@ -271,13 +271,6 @@
                     "description": "Additional options to pass to PlusCal transpiler.",
                     "maxLength": 1000
                 },
-                "tlaplus.tlc.modelChecker.options": {
-                    "type": "string",
-                    "scope": "window",
-                    "default": "",
-                    "description": "Additional options to pass to TLC.",
-                    "maxLength": 1000
-                },
                 "tlaplus.tlc.modelChecker.createOutFiles": {
                     "type": "boolean",
                     "scope": "window",

--- a/package.json
+++ b/package.json
@@ -278,6 +278,12 @@
                     "description": "Additional options to pass to TLC.",
                     "maxLength": 1000
                 },
+                "tlaplus.tlc.modelChecker.optionsPrompt": {
+                    "type": "boolean",
+                    "scope": "window",
+                    "default": true,
+                    "description": "Show prompt for TLC options each time model checking is run."
+                },
                 "tlaplus.tlc.modelChecker.createOutFiles": {
                     "type": "boolean",
                     "scope": "window",

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -163,7 +163,11 @@ export async function doCheckModel(
         lastCheckFiles = specFiles;
         vscode.commands.executeCommand('setContext', CTX_TLC_CAN_RUN_AGAIN, true);
         updateStatusBarItem(true);
-        const procInfo = await runTlc(specFiles.tlaFilePath, path.basename(specFiles.cfgFilePath));
+        const procInfo = await runTlc(
+            specFiles.tlaFilePath,
+            path.basename(specFiles.cfgFilePath),
+            extContext.globalState
+        );
         if (procInfo === undefined) {
             // Command cancelled by user
             return undefined;

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -25,6 +25,7 @@ const TEMPLATE_CFG_PATH = path.resolve(__dirname, '../../../tools/template.cfg')
 
 let checkProcess: ChildProcess | undefined;
 let lastCheckFiles: SpecFiles | undefined;
+let lastCheckOptions: string | undefined;
 const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
 const outChannel = new ToolOutputChannel('TLC', mapTlcOutputLine);
 
@@ -160,10 +161,26 @@ export async function doCheckModel(
     diagnostic: vscode.DiagnosticCollection
 ): Promise<ModelCheckResult | undefined> {
     try {
+        // -config is not shown as an option by default so the same options can be used without modification across
+        // multiple modules.
+        const customOptions = await vscode.window.showInputBox({
+            value: lastCheckOptions || `-coverage 1`,
+            prompt: 'Additional options to pass to TLC.',
+            // Ignoring focus changes allows users to click out to a different window to check potential TLC options
+            // without getting rid of what they've typed so far.
+            ignoreFocusOut: true,
+        });
+        if (customOptions === undefined) {
+            // Command cancelled by user
+            return undefined;
+        } else {
+            lastCheckOptions = customOptions;
+        }
+
         lastCheckFiles = specFiles;
         vscode.commands.executeCommand('setContext', CTX_TLC_CAN_RUN_AGAIN, true);
         updateStatusBarItem(true);
-        const procInfo = await runTlc(specFiles.tlaFilePath, path.basename(specFiles.cfgFilePath));
+        const procInfo = await runTlc(specFiles.tlaFilePath, path.basename(specFiles.cfgFilePath), customOptions);
         outChannel.bindTo(procInfo);
         checkProcess = procInfo.process;
         checkProcess.on('close', () => {

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -163,11 +163,7 @@ export async function doCheckModel(
         lastCheckFiles = specFiles;
         vscode.commands.executeCommand('setContext', CTX_TLC_CAN_RUN_AGAIN, true);
         updateStatusBarItem(true);
-        const procInfo = await runTlc(
-            specFiles.tlaFilePath,
-            path.basename(specFiles.cfgFilePath),
-            extContext.globalState
-        );
+        const procInfo = await runTlc(specFiles.tlaFilePath, path.basename(specFiles.cfgFilePath));
         if (procInfo === undefined) {
             // Command cancelled by user
             return undefined;

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -48,7 +48,7 @@ export async function checkModel(
     if (!specFiles) {
         return;
     }
-    doCheckModel(specFiles, true, extContext, diagnostic);
+    doCheckModel(specFiles, true, extContext, diagnostic, true);
 }
 
 export async function runLastCheckAgain(
@@ -62,7 +62,7 @@ export async function runLastCheckAgain(
     if (!canRunTlc(extContext)) {
         return;
     }
-    doCheckModel(lastCheckFiles, true, extContext, diagnostic);
+    doCheckModel(lastCheckFiles, true, extContext, diagnostic, false);
 }
 
 export async function checkModelCustom(
@@ -91,7 +91,7 @@ export async function checkModelCustom(
         doc.uri.fsPath,
         path.join(path.dirname(doc.uri.fsPath), cfgFileName)
     );
-    doCheckModel(specFiles, true, extContext, diagnostic);
+    doCheckModel(specFiles, true, extContext, diagnostic, true);
 }
 
 /**
@@ -157,13 +157,14 @@ export async function doCheckModel(
     specFiles: SpecFiles,
     showCheckResultView: boolean,
     extContext: vscode.ExtensionContext,
-    diagnostic: vscode.DiagnosticCollection
+    diagnostic: vscode.DiagnosticCollection,
+    showOptionsPrompt: boolean,
 ): Promise<ModelCheckResult | undefined> {
     try {
         lastCheckFiles = specFiles;
         vscode.commands.executeCommand('setContext', CTX_TLC_CAN_RUN_AGAIN, true);
         updateStatusBarItem(true);
-        const procInfo = await runTlc(specFiles.tlaFilePath, path.basename(specFiles.cfgFilePath));
+        const procInfo = await runTlc(specFiles.tlaFilePath, path.basename(specFiles.cfgFilePath), showOptionsPrompt);
         if (procInfo === undefined) {
             // Command cancelled by user
             return undefined;

--- a/src/commands/evaluateExpression.ts
+++ b/src/commands/evaluateExpression.ts
@@ -95,7 +95,7 @@ async function doEvaluateExpression(
     outChannel.clear();
     outChannel.appendLine(`Evaluating constant expression:\n${expr}\n`);
     outChannel.revealWindow();
-    const checkResult = await doCheckModel(specFiles, false, extContext, diagnostic);
+    const checkResult = await doCheckModel(specFiles, false, extContext, diagnostic, false);
     displayResult(checkResult);
     deleteDir(model.dirPath);
 }

--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -90,8 +90,8 @@ export async function runTex(tlaFilePath: string): Promise<ToolProcessInfo> {
     );
 }
 
-export async function runTlc(tlaFilePath: string, cfgFilePath: string): Promise<ToolProcessInfo> {
-    const customOptions = getConfigOptions(CFG_TLC_OPTIONS);
+export async function runTlc(tlaFilePath: string, cfgFilePath: string, customOptions: string): Promise<ToolProcessInfo> {
+    const splitCustomOptions = splitArguments(customOptions);
     const javaOptions = [];
     const shareStats = vscode.workspace.getConfiguration().get<ShareOption>(CFG_TLC_STATISTICS_TYPE);
     if (shareStats !== ShareOption.DoNotShare) {
@@ -100,7 +100,7 @@ export async function runTlc(tlaFilePath: string, cfgFilePath: string): Promise<
     return runTool(
         TlaTool.TLC,
         tlaFilePath,
-        buildTlcOptions(tlaFilePath, cfgFilePath, customOptions),
+        buildTlcOptions(tlaFilePath, cfgFilePath, splitCustomOptions),
         javaOptions
     );
 }
@@ -178,7 +178,6 @@ export function buildTlcOptions(tlaFilePath: string, cfgFilePath: string, custom
             .replace(VAR_TLC_MODEL_NAME, path.basename(cfgFilePath, '.cfg'));
     });
     const opts = [path.basename(tlaFilePath), '-tool', '-modelcheck'];
-    addValueOrDefault('-coverage', '1', custOpts, opts);
     addValueOrDefault('-config', cfgFilePath, custOpts, opts);
     return opts.concat(custOpts);
 }

--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -278,11 +278,11 @@ export async function getTlcOptions(): Promise<string[] | undefined> {
         // Command cancelled by user
         return undefined;
     } else {
-        // Save user-enterred options as new configuration to persist between sessions. The configuration is saved
-        // at the workspace, rather than global, level so user-enterred options will not be persisted across
-        // workspaces.
-        vscode.workspace.getConfiguration().update(
-            CFG_TLC_OPTIONS, customOptions, vscode.ConfigurationTarget.Workspace);
+        // Save user-enterred options as new configuration to persist between sessions. If a workspace is open, the
+        // configuration is saved at the workspace level. Otherwise it is saved at the global level.
+        const workspaceOpen = vscode.workspace.name !== undefined;
+        const configurationTarget = workspaceOpen ? vscode.ConfigurationTarget.Workspace : vscode.ConfigurationTarget.Global;
+        vscode.workspace.getConfiguration().update(CFG_TLC_OPTIONS, customOptions, configurationTarget);
     }
     return splitArguments(customOptions);
 }

--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -10,8 +10,9 @@ import { ToolOutputChannel } from './outputChannels';
 
 const CFG_JAVA_HOME = 'tlaplus.java.home';
 const CFG_JAVA_OPTIONS = 'tlaplus.java.options';
-const CFG_TLC_OPTIONS = 'tlaplus.tlc.modelChecker.options';
 const CFG_PLUSCAL_OPTIONS = 'tlaplus.pluscal.options';
+
+const STORAGE_TLC_OPTIONS = 'tlaplus.tlc.modelChecker.options';
 
 const VAR_TLC_SPEC_NAME = /\$\{specName\}/g;
 const VAR_TLC_MODEL_NAME = /\$\{modelName\}/g;
@@ -90,8 +91,12 @@ export async function runTex(tlaFilePath: string): Promise<ToolProcessInfo> {
     );
 }
 
-export async function runTlc(tlaFilePath: string, cfgFilePath: string): Promise<ToolProcessInfo | undefined> {
-    const customOptions = await getTlcOptions();
+export async function runTlc(
+    tlaFilePath: string,
+    cfgFilePath: string,
+    storage: vscode.Memento
+): Promise<ToolProcessInfo | undefined> {
+    const customOptions = await getTlcOptions(storage);
     if (customOptions === undefined) {
         // Command cancelled by user
         return undefined;
@@ -263,12 +268,12 @@ function getConfigOptions(cfgName: string): string[] {
     return splitArguments(optsString);
 }
 
-export async function getTlcOptions(): Promise<string[] | undefined> {
+export async function getTlcOptions(storage: vscode.Memento): Promise<string[] | undefined> {
     const defaultOptions = '-coverage 1';
     // -config is not shown as an option by default so the same options can be used without modification across
     // multiple modules.
     const customOptions = await vscode.window.showInputBox({
-        value: vscode.workspace.getConfiguration().get<string>(CFG_TLC_OPTIONS) || defaultOptions,
+        value: storage.get<string>(STORAGE_TLC_OPTIONS) || defaultOptions,
         prompt: 'Additional options to pass to TLC.',
         // Ignoring focus changes allows users to click out to a different window to check potential TLC options
         // without getting rid of what they've typed so far.
@@ -278,13 +283,8 @@ export async function getTlcOptions(): Promise<string[] | undefined> {
         // Command cancelled by user
         return undefined;
     } else {
-        // Save user-enterred options as new configuration to persist between sessions. If a workspace is open, the
-        // configuration is saved at the workspace level. Otherwise it is saved at the global level.
-        const workspaceOpen = vscode.workspace.name !== undefined;
-        const configurationTarget = workspaceOpen ?
-            vscode.ConfigurationTarget.Workspace :
-            vscode.ConfigurationTarget.Global;
-        vscode.workspace.getConfiguration().update(CFG_TLC_OPTIONS, customOptions, configurationTarget);
+        // Save user-enterred options to persist between sessions.
+        storage.update(STORAGE_TLC_OPTIONS, customOptions);
     }
     return splitArguments(customOptions);
 }

--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -12,6 +12,7 @@ const CFG_JAVA_HOME = 'tlaplus.java.home';
 const CFG_JAVA_OPTIONS = 'tlaplus.java.options';
 const CFG_TLC_OPTIONS = 'tlaplus.tlc.modelChecker.options';
 const CFG_PLUSCAL_OPTIONS = 'tlaplus.pluscal.options';
+const CFG_TLC_OPTIONS_PROMPT = 'tlaplus.tlc.modelChecker.optionsPrompt';
 
 const VAR_TLC_SPEC_NAME = /\$\{specName\}/g;
 const VAR_TLC_MODEL_NAME = /\$\{modelName\}/g;
@@ -267,13 +268,23 @@ function getConfigOptions(cfgName: string): string[] {
     return splitArguments(optsString);
 }
 
+/**
+ * Gets the options for TLC. A prompt is shown to the user to confirm or modify the options iff both showPrompt and
+ * the tlaplus.tlc.modelChecker.optionsPrompt settings are true. The options are pre-populated from the settings when
+ * possible. User-enterred options are stored in the settings for future use.
+ *
+ * @param showPrompt Show a prompt to the user
+ * @returns Array of string options for TLC, or undefined if the user cancelled the prompt
+ */
 export async function getTlcOptions(showPrompt: boolean): Promise<string[] | undefined> {
     // -config is not shown as an option by default so the same options can be used without modification across
     // multiple modules.
     const defaultOptions = '-coverage 1';
     const prevConfig = vscode.workspace.getConfiguration().get<string>(CFG_TLC_OPTIONS) || defaultOptions;
 
-    const customOptions = showPrompt ?
+    const promptSetting = vscode.workspace.getConfiguration().get<boolean>(CFG_TLC_OPTIONS_PROMPT);
+
+    const customOptions = showPrompt && promptSetting ?
         await vscode.window.showInputBox({
             value: prevConfig,
             prompt: 'Additional options to pass to TLC.',

--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -281,7 +281,9 @@ export async function getTlcOptions(): Promise<string[] | undefined> {
         // Save user-enterred options as new configuration to persist between sessions. If a workspace is open, the
         // configuration is saved at the workspace level. Otherwise it is saved at the global level.
         const workspaceOpen = vscode.workspace.name !== undefined;
-        const configurationTarget = workspaceOpen ? vscode.ConfigurationTarget.Workspace : vscode.ConfigurationTarget.Global;
+        const configurationTarget = workspaceOpen ?
+            vscode.ConfigurationTarget.Workspace :
+            vscode.ConfigurationTarget.Global;
         vscode.workspace.getConfiguration().update(CFG_TLC_OPTIONS, customOptions, configurationTarget);
     }
     return splitArguments(customOptions);

--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -90,7 +90,11 @@ export async function runTex(tlaFilePath: string): Promise<ToolProcessInfo> {
     );
 }
 
-export async function runTlc(tlaFilePath: string, cfgFilePath: string, customOptions: string): Promise<ToolProcessInfo> {
+export async function runTlc(
+    tlaFilePath: string,
+    cfgFilePath: string,
+    customOptions: string
+): Promise<ToolProcessInfo> {
     const splitCustomOptions = splitArguments(customOptions);
     const javaOptions = [];
     const shareStats = vscode.workspace.getConfiguration().get<ShareOption>(CFG_TLC_STATISTICS_TYPE);
@@ -257,6 +261,20 @@ function addReturnCodeHandler(proc: ChildProcess, toolName?: string) {
 function getConfigOptions(cfgName: string): string[] {
     const optsString = vscode.workspace.getConfiguration().get<string>(cfgName) || '';
     return splitArguments(optsString);
+}
+
+export function getTlcOptions(): string {
+    return vscode.workspace.getConfiguration().get<string>(CFG_TLC_OPTIONS) || '-coverage 1';
+}
+
+/**
+ * Updates the TLC configuration value. By default this changes the configuration for the workspace.
+ */
+export function updateTlcOptions(
+    newValue: string,
+    configurationTarget = vscode.ConfigurationTarget.Workspace
+): Thenable<void> {
+    return vscode.workspace.getConfiguration().update(CFG_TLC_OPTIONS, newValue, configurationTarget);
 }
 
 function buildCommandLine(programName: string, args: string[]): string {

--- a/tests/suite/tla2tools.test.ts
+++ b/tests/suite/tla2tools.test.ts
@@ -21,14 +21,14 @@ suite('TLA+ Tools Test Suite', () => {
     test('Provides default TLC options', () => {
         assert.deepEqual(
             buildTlcOptions('/path/to/module.tla', '/path/to/module.cfg', []),
-            ['module.tla', '-tool', '-modelcheck', '-coverage', '1', '-config', '/path/to/module.cfg']
+            ['module.tla', '-tool', '-modelcheck', '-config', '/path/to/module.cfg']
         );
     });
 
     test('Adds custom TLC options', () => {
         assert.deepEqual(
             buildTlcOptions('/path/to/module.tla', '/path/to/module.cfg', ['-deadlock', '-checkpoint', '5']),
-            ['module.tla', '-tool', '-modelcheck', '-coverage', '1', '-config', '/path/to/module.cfg',
+            ['module.tla', '-tool', '-modelcheck', '-config', '/path/to/module.cfg',
                 '-deadlock', '-checkpoint', '5']
         );
     });
@@ -40,7 +40,7 @@ suite('TLA+ Tools Test Suite', () => {
                 '/path/to/module.cfg',
                 ['-deadlock', '-config', '/path/to/another.cfg', '-nowarning']
             ), [
-                'module.tla', '-tool', '-modelcheck', '-coverage', '1', '-config', '/path/to/another.cfg',
+                'module.tla', '-tool', '-modelcheck', '-config', '/path/to/another.cfg',
                 '-deadlock', '-nowarning'
             ]
         );
@@ -53,8 +53,8 @@ suite('TLA+ Tools Test Suite', () => {
                 '/path/to/module.cfg',
                 ['-deadlock', '-coverage', '2', '-nowarning']
             ), [
-                'module.tla', '-tool', '-modelcheck', '-coverage', '2', '-config', '/path/to/module.cfg',
-                '-deadlock', '-nowarning'
+                'module.tla', '-tool', '-modelcheck', '-config', '/path/to/module.cfg',
+                '-deadlock', '-coverage', '2', '-nowarning'
             ]
         );
     });
@@ -66,7 +66,7 @@ suite('TLA+ Tools Test Suite', () => {
                 '/path/to/bar.cfg',
                 ['-dump', 'dot', '${specName}.dot']
             ), [
-                'foo.tla', '-tool', '-modelcheck', '-coverage', '1', '-config', '/path/to/bar.cfg',
+                'foo.tla', '-tool', '-modelcheck', '-config', '/path/to/bar.cfg',
                 '-dump', 'dot', 'foo.dot'
             ]
         );
@@ -79,7 +79,7 @@ suite('TLA+ Tools Test Suite', () => {
                 '/path/to/bar.cfg',
                 ['-dump', 'dot', '${modelName}.dot']
             ), [
-                'foo.tla', '-tool', '-modelcheck', '-coverage', '1', '-config', '/path/to/bar.cfg',
+                'foo.tla', '-tool', '-modelcheck', '-config', '/path/to/bar.cfg',
                 '-dump', 'dot', 'bar.dot'
             ]
         );


### PR DESCRIPTION
Addresses #172.

The idea behind this PR is to pop up an input box prompt with the TLC options when running the "Check model with TLC" command. This both shows the user what options TLC will run with and gives them a convenient place to change the options. This PR then saves the user-provided options to the workspace settings if a workspace is open, or to the global settings if not, allowing the same options to be prompted to the user for the next run, even across sessions.

This PR adds some user friction, but in most cases it just requires the user to press enter since the options are pre-populated from the previous run.

Outstanding questions/concerns I have with this PR are:
- Is the added user friction annoying enough to warrant adding a checkbox to the settings to disable the prompt?
- I omit the -config argument from pre-populating by default since I want users to be able to re-use the same options across multiple modules, however I include the -coverage argument. This means that default options are now defined in two places: coverage in `getTlcOptions()` and config in `buildTlcOptions()`.
- TLC options are saved to workspace settings when possible, and global settings when not. Should they instead always be saved to the global settings?
- Tests for `getTlcOptions()` would require UI interaction. This would mean integrating a framework like [vscode-extension-tester](https://github.com/redhat-developer/vscode-extension-tester) or [puppeteer](https://developers.google.com/web/tools/puppeteer)/selenium. This would add complexity and a maintenance burden. Would it be worth it?