### PR TITLE
Add command to run last model check with options

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,11 @@
                 "category": "TLA+"
             },
             {
+                "command": "tlaplus.model.check.runAgainWithOptions",
+                "title": "Run last model check with new options",
+                "category": "TLA+"
+            },
+            {
                 "command": "tlaplus.model.check.stop",
                 "title": "Stop model checking process",
                 "category": "TLA+"
@@ -198,6 +203,10 @@
                 },
                 {
                     "command": "tlaplus.model.check.runAgain",
+                    "when": "tlaplus.tlc.canRunAgain"
+                },
+                {
+                    "command": "tlaplus.model.check.runAgainWithOptions",
                     "when": "tlaplus.tlc.canRunAgain"
                 },
                 {

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -13,6 +13,7 @@ import { ToolOutputChannel } from '../outputChannels';
 
 export const CMD_CHECK_MODEL_RUN = 'tlaplus.model.check.run';
 export const CMD_CHECK_MODEL_RUN_AGAIN = 'tlaplus.model.check.runAgain';
+export const CMD_CHECK_MODEL_RUN_AGAIN_WITH_OPTIONS = 'tlaplus.model.check.runAgainWithOptions';
 export const CMD_CHECK_MODEL_CUSTOM_RUN = 'tlaplus.model.check.customRun';
 export const CMD_CHECK_MODEL_STOP = 'tlaplus.model.check.stop';
 export const CMD_CHECK_MODEL_DISPLAY = 'tlaplus.model.check.display';
@@ -53,7 +54,8 @@ export async function checkModel(
 
 export async function runLastCheckAgain(
     diagnostic: vscode.DiagnosticCollection,
-    extContext: vscode.ExtensionContext
+    extContext: vscode.ExtensionContext,
+    withOptions = false,
 ): Promise<void> {
     if (!lastCheckFiles) {
         vscode.window.showWarningMessage('No last check to run');
@@ -62,7 +64,7 @@ export async function runLastCheckAgain(
     if (!canRunTlc(extContext)) {
         return;
     }
-    doCheckModel(lastCheckFiles, true, extContext, diagnostic, false);
+    doCheckModel(lastCheckFiles, true, extContext, diagnostic, withOptions);
 }
 
 export async function checkModelCustom(

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -55,7 +55,7 @@ export async function checkModel(
 export async function runLastCheckAgain(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext,
-    withOptions = false,
+    withNewOptions = false,
 ): Promise<void> {
     if (!lastCheckFiles) {
         vscode.window.showWarningMessage('No last check to run');
@@ -64,7 +64,7 @@ export async function runLastCheckAgain(
     if (!canRunTlc(extContext)) {
         return;
     }
-    doCheckModel(lastCheckFiles, true, extContext, diagnostic, withOptions);
+    doCheckModel(lastCheckFiles, true, extContext, diagnostic, withNewOptions);
 }
 
 export async function checkModelCustom(

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { CMD_CHECK_MODEL_RUN, CMD_CHECK_MODEL_STOP, CMD_CHECK_MODEL_DISPLAY, CMD_SHOW_TLC_OUTPUT,
     CMD_CHECK_MODEL_CUSTOM_RUN, checkModel, displayModelChecking, stopModelChecking,
-    showTlcOutput, checkModelCustom, CMD_CHECK_MODEL_RUN_AGAIN, runLastCheckAgain} from './commands/checkModel';
+    showTlcOutput, checkModelCustom, CMD_CHECK_MODEL_RUN_AGAIN, CMD_CHECK_MODEL_RUN_AGAIN_WITH_OPTIONS,
+    runLastCheckAgain} from './commands/checkModel';
 import { CMD_EVALUATE_SELECTION, evaluateSelection, CMD_EVALUATE_EXPRESSION,
     evaluateExpression } from './commands/evaluateExpression';
 import { parseModule, CMD_PARSE_MODULE } from './commands/parseModule';
@@ -50,6 +51,9 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand(
             CMD_CHECK_MODEL_RUN_AGAIN,
             () => runLastCheckAgain(diagnostic, context)),
+        vscode.commands.registerCommand(
+            CMD_CHECK_MODEL_RUN_AGAIN_WITH_OPTIONS,
+            () => runLastCheckAgain(diagnostic, context, true)),
         vscode.commands.registerCommand(
             CMD_CHECK_MODEL_CUSTOM_RUN,
             () => checkModelCustom(diagnostic, context)),


### PR DESCRIPTION
Addresses #215.

This PR adds a command ("Run last model check with new options") that works when the model checking pane is focused.

Alternative implementations could include adding a link to the model checking webview that runs this command, or updating the `tlaplus.model.check.run` command to also be enabled when the model checking pane is focused. Unfortunately I wasn't able to find a good way to enable the command if a webview is selected that doesn't involve [manually setting the context](https://code.visualstudio.com/api/references/when-clause-contexts#add-a-custom-when-clause-context) so I instead opted for a new command that re-uses existing functions.