### PR TITLE
Enable check model command from model checking panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1551,6 +1551,11 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "neverthrow": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-4.2.1.tgz",
+            "integrity": "sha512-faWQGNqVQrXOuG8K7E0PRzsfBHzfVqeDX9nwawKDseuH/qEGIH02Nrq03OJOs5eTFML03xeol3otzagPoHyEPA=="
+        },
         "node": {
             "version": "12.12.0",
             "resolved": "https://registry.npmjs.org/node/-/node-12.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
                 },
                 {
                     "command": "tlaplus.model.check.run",
-                    "when": "editorLangId == tlaplus || editorLangId == tlaplus_cfg"
+                    "when": "editorLangId == tlaplus || editorLangId == tlaplus_cfg || tlaplus.tlc.canRunAgain"
                 },
                 {
                     "command": "tlaplus.model.check.runAgain",
@@ -402,6 +402,7 @@
     "dependencies": {
         "await-notify": "^1.0.1",
         "moment": "^2.24.0",
+        "neverthrow": "^4.2.1",
         "vscode-debugadapter": "^1.42.1"
     }
 }

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -41,13 +41,7 @@ export async function checkModel(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext
 ): Promise<void> {
-    // We need to check canRunTlc separately from getActiveEditorFileUri() since checkModel could silently drop an
-    // error related to canRunTlc when checking using the previous spec.
-    if (!canRunTlc(extContext)) {
-        return;
-    }
-
-    const uriResult = fileUri ? ok(fileUri) : getActiveEditorFileUri(extContext);
+    const uriResult = fileUri ? ok(fileUri) : getActiveEditorFileUri();
 
     const specFilesResult = await uriResult.match(
         async (uri): Promise<Result<SpecFiles, ModelCheckingError>> => {
@@ -81,9 +75,6 @@ export async function runLastCheckAgain(
         vscode.window.showWarningMessage('No last check to run');
         return;
     }
-    if (!canRunTlc(extContext)) {
-        return;
-    }
     doCheckModel(lastCheckFiles, true, extContext, diagnostic, false);
 }
 
@@ -91,7 +82,7 @@ export async function checkModelCustom(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext
 ): Promise<void> {
-    const editorResult = getEditorIfCanRunTlc(extContext);
+    const editorResult = getEditor();
     if (editorResult.isErr()) {
         vscode.window.showErrorMessage(editorResult.error.message);
         return;
@@ -139,8 +130,8 @@ export function showTlcOutput(): void {
     outChannel.revealWindow();
 }
 
-function getActiveEditorFileUri(extContext: vscode.ExtensionContext): Result<vscode.Uri, ModelCheckingError> {
-    const editorResult = getEditorIfCanRunTlc(extContext);
+function getActiveEditorFileUri(): Result<vscode.Uri, ModelCheckingError> {
+    const editorResult = getEditor();
 
     if (editorResult.isErr()) {
         return err(editorResult.error);
@@ -155,12 +146,7 @@ function getActiveEditorFileUri(extContext: vscode.ExtensionContext): Result<vsc
     return ok(doc.uri);
 }
 
-export function getEditorIfCanRunTlc(
-    extContext: vscode.ExtensionContext
-): Result<vscode.TextEditor, ModelCheckingError> {
-    if (!canRunTlc(extContext)) {
-        return err(new ModelCheckingError('Cannot run TLC in the current context'));
-    }
+export function getEditor(): Result<vscode.TextEditor, ModelCheckingError> {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
         return err(new ModelCheckingError('No editor is active, cannot find a TLA+ model to check'));
@@ -168,7 +154,7 @@ export function getEditorIfCanRunTlc(
     return ok(editor);
 }
 
-function canRunTlc(extContext: vscode.ExtensionContext): boolean {
+export function canRunTlc(extContext: vscode.ExtensionContext): boolean {
     if (checkProcess) {
         vscode.window.showWarningMessage(
             'Another model checking process is currently running',
@@ -188,6 +174,11 @@ export async function doCheckModel(
     extraOpts: string[] = [],
     debuggerPortCallback?: (port?: number) => void
 ): Promise<ModelCheckResult | undefined> {
+    // Note: canRunTlc prints a warning message if it returns false
+    if (!canRunTlc(extContext)) {
+        return;
+    }
+
     try {
         lastCheckFiles = specFiles;
         vscode.commands.executeCommand('setContext', CTX_TLC_CAN_RUN_AGAIN, true);

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -7,9 +7,10 @@ import { updateCheckResultView, revealEmptyCheckResultView, revealLastCheckResul
 import { applyDCollection } from '../diagnostic';
 import { ChildProcess } from 'child_process';
 import { saveStreamToFile } from '../outputSaver';
-import { replaceExtension, LANG_TLAPLUS, LANG_TLAPLUS_CFG, listFiles, exists } from '../common';
+import { replaceExtension, LANG_TLAPLUS, LANG_TLAPLUS_CFG, listFiles, exists, ModelCheckingError } from '../common';
 import { ModelCheckResultSource, ModelCheckResult, SpecFiles } from '../model/check';
 import { ToolOutputChannel } from '../outputChannels';
+import { Result, ok, err } from 'neverthrow';
 
 export const CMD_CHECK_MODEL_RUN = 'tlaplus.model.check.run';
 export const CMD_CHECK_MODEL_RUN_AGAIN = 'tlaplus.model.check.runAgain';
@@ -40,15 +41,36 @@ export async function checkModel(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext
 ): Promise<void> {
-    const uri = fileUri ? fileUri : getActiveEditorFileUri(extContext);
-    if (!uri) {
+    // We need to check canRunTlc separately from getActiveEditorFileUri() since checkModel could silently drop an
+    // error related to canRunTlc when checking using the previous spec.
+    if (!canRunTlc(extContext)) {
         return;
     }
-    const specFiles = await getSpecFiles(uri);
-    if (!specFiles) {
+
+    const uriResult = fileUri ? ok(fileUri) : getActiveEditorFileUri(extContext);
+
+    const specFilesResult = await uriResult.match(
+        async (uri): Promise<Result<SpecFiles, ModelCheckingError>> => {
+            const files = await getSpecFiles(uri);
+            if (!files) {
+                return err(new ModelCheckingError('Could not load spec files.'));
+            }
+            return ok(files);
+        },
+        // Use last checked spec if no active TLA+ files are found.
+        async (error: unknown): Promise<Result<SpecFiles, ModelCheckingError>> => lastCheckFiles ?
+            ok(lastCheckFiles) :
+            err(new ModelCheckingError(
+                'No active TLA+ file or previous spec found. Switch to the .tla or .cfg file to check.'
+            ))
+    );
+
+    if (specFilesResult.isErr()) {
+        vscode.window.showErrorMessage(specFilesResult.error.message);
         return;
     }
-    doCheckModel(specFiles, true, extContext, diagnostic, true);
+
+    doCheckModel(specFilesResult.value, true, extContext, diagnostic, true);
 }
 
 export async function runLastCheckAgain(
@@ -69,11 +91,12 @@ export async function checkModelCustom(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext
 ): Promise<void> {
-    const editor = getEditorIfCanRunTlc(extContext);
-    if (!editor) {
+    const editorResult = getEditorIfCanRunTlc(extContext);
+    if (editorResult.isErr()) {
+        vscode.window.showErrorMessage(editorResult.error.message);
         return;
     }
-    const doc = editor.document;
+    const doc = editorResult.value.document;
     if (doc.languageId !== LANG_TLAPLUS) {
         vscode.window.showWarningMessage('File in the active editor is not a .tla, it cannot be checked as a model');
         return;
@@ -116,30 +139,33 @@ export function showTlcOutput(): void {
     outChannel.revealWindow();
 }
 
-function getActiveEditorFileUri(extContext: vscode.ExtensionContext): vscode.Uri | undefined {
-    const editor = getEditorIfCanRunTlc(extContext);
-    if (!editor) {
-        return undefined;
+function getActiveEditorFileUri(extContext: vscode.ExtensionContext): Result<vscode.Uri, ModelCheckingError> {
+    const editorResult = getEditorIfCanRunTlc(extContext);
+
+    if (editorResult.isErr()) {
+        return err(editorResult.error);
     }
-    const doc = editor.document;
+
+    const doc = editorResult.value.document;
     if (doc.languageId !== LANG_TLAPLUS && doc.languageId !== LANG_TLAPLUS_CFG) {
-        vscode.window.showWarningMessage(
-            'File in the active editor is not a .tla or .cfg file, it cannot be checked as a model');
-        return undefined;
+        return err(new ModelCheckingError(
+            'File in the active editor is not a .tla or .cfg file, it cannot be checked as a model'
+        ));
     }
-    return doc.uri;
+    return ok(doc.uri);
 }
 
-export function getEditorIfCanRunTlc(extContext: vscode.ExtensionContext): vscode.TextEditor | undefined {
+export function getEditorIfCanRunTlc(
+    extContext: vscode.ExtensionContext
+): Result<vscode.TextEditor, ModelCheckingError> {
     if (!canRunTlc(extContext)) {
-        return undefined;
+        return err(new ModelCheckingError('Cannot run TLC in the current context'));
     }
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
-        vscode.window.showWarningMessage('No editor is active, cannot find a TLA+ model to check');
-        return undefined;
+        return err(new ModelCheckingError('No editor is active, cannot find a TLA+ model to check'));
     }
-    return editor;
+    return ok(editor);
 }
 
 function canRunTlc(extContext: vscode.ExtensionContext): boolean {

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -43,28 +43,25 @@ export async function checkModel(
 ): Promise<void> {
     const uriResult = fileUri ? ok(fileUri) : getActiveEditorFileUri();
 
-    const specFilesResult = await uriResult.match(
-        async (uri): Promise<Result<SpecFiles, ModelCheckingError>> => {
-            const files = await getSpecFiles(uri);
-            if (!files) {
-                return err(new ModelCheckingError('Could not load spec files.'));
-            }
-            return ok(files);
-        },
-        // Use last checked spec if no active TLA+ files are found.
-        async (error: unknown): Promise<Result<SpecFiles, ModelCheckingError>> => lastCheckFiles ?
-            ok(lastCheckFiles) :
-            err(new ModelCheckingError(
-                'No active TLA+ file or previous spec found. Switch to the .tla or .cfg file to check.'
-            ))
-    );
+    let specFiles;
 
-    if (specFilesResult.isErr()) {
-        vscode.window.showErrorMessage(specFilesResult.error.message);
-        return;
+    if (uriResult.isErr()) {
+        // Use last checked spec if no active TLA+ files are found.
+        if (!lastCheckFiles) {
+            vscode.window.showErrorMessage(
+                'No active TLA+ file or previous spec found. Switch to the .tla or .cfg file to check.');
+            return;
+        }
+        specFiles = lastCheckFiles;
+    } else {
+        specFiles = await getSpecFiles(uriResult.value);
+        if (!specFiles) {
+            vscode.window.showErrorMessage('Could not load spec files.');
+            return;
+        }
     }
 
-    doCheckModel(specFilesResult.value, true, extContext, diagnostic, true);
+    doCheckModel(specFiles, true, extContext, diagnostic, true);
 }
 
 export async function runLastCheckAgain(

--- a/src/commands/evaluateExpression.ts
+++ b/src/commands/evaluateExpression.ts
@@ -22,10 +22,13 @@ export async function evaluateSelection(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext
 ): Promise<void> {
-    const editor = getEditorIfCanRunTlc(extContext);
-    if (!editor) {
+    const editorResult = getEditorIfCanRunTlc(extContext);
+    if (editorResult.isErr()) {
+        vscode.window.showErrorMessage(editorResult.error.message);
         return;
     }
+    const editor = editorResult.value;
+
     const selRange = new vscode.Range(editor.selection.start, editor.selection.end);
     const selText = editor.document.getText(selRange);
     doEvaluateExpression(editor, selText, diagnostic, extContext);
@@ -38,8 +41,9 @@ export async function evaluateExpression(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext
 ): Promise<void> {
-    const editor = getEditorIfCanRunTlc(extContext);
-    if (!editor) {
+    const editorResult = getEditorIfCanRunTlc(extContext);
+    if (editorResult.isErr()) {
+        vscode.window.showErrorMessage(editorResult.error.message);
         return;
     }
     vscode.window.showInputBox({
@@ -51,7 +55,7 @@ export async function evaluateExpression(
             return;
         }
         lastEvaluatedExpression = expr;
-        doEvaluateExpression(editor, expr, diagnostic, extContext);
+        doEvaluateExpression(editorResult.value, expr, diagnostic, extContext);
     });
 }
 

--- a/src/commands/evaluateExpression.ts
+++ b/src/commands/evaluateExpression.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { replaceExtension, deleteDir, readFile, exists } from '../common';
-import { getEditorIfCanRunTlc, doCheckModel } from './checkModel';
+import { getEditor, canRunTlc, doCheckModel } from './checkModel';
 import { createCustomModel } from './customModel';
 import { ToolOutputChannel } from '../outputChannels';
 import { ModelCheckResult, CheckState, SequenceValue, Value, OutputLine, SpecFiles } from '../model/check';
@@ -22,7 +22,7 @@ export async function evaluateSelection(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext
 ): Promise<void> {
-    const editorResult = getEditorIfCanRunTlc(extContext);
+    const editorResult = getEditor();
     if (editorResult.isErr()) {
         vscode.window.showErrorMessage(editorResult.error.message);
         return;
@@ -41,7 +41,7 @@ export async function evaluateExpression(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext
 ): Promise<void> {
-    const editorResult = getEditorIfCanRunTlc(extContext);
+    const editorResult = getEditor();
     if (editorResult.isErr()) {
         vscode.window.showErrorMessage(editorResult.error.message);
         return;
@@ -65,6 +65,11 @@ async function doEvaluateExpression(
     diagnostic: vscode.DiagnosticCollection,
     extContext: vscode.ExtensionContext
 ) {
+    // Note: canRunTlc prints a warning message if it returns false
+    if (!canRunTlc(extContext)) {
+        return;
+    }
+
     const eExpr = expr.trim();
     if (eExpr === '') {
         vscode.window.showWarningMessage('Nothing to evaluate.');

--- a/src/common.ts
+++ b/src/common.ts
@@ -21,6 +21,17 @@ export class ParsingError extends Error {
     }
 }
 
+/**
+ * Occurs when there's a model checking problem.
+ *
+ * For example, this error can occur if the checked file is not a TLA+ file and therefore cannot be model checked.
+ */
+export class ModelCheckingError extends Error {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
 export function pathToUri(filePath: string): vscode.Uri {
     return vscode.Uri.file(filePath).with({ scheme: 'file' });
 }


### PR DESCRIPTION
Addresses #215, replaces #216. 

This PR extends the `tlaplus.model.check.run` command to be enabled whenever `tlaplus.tlc.canRunAgain` is true. This has the effect of showing the check model command when the model checking pane is active. When no TLA+ file is active, the command falls back on using the last checked spec. The flow of the checkModel function roughly follows:

1. If given a file URI , read the spec from the file.
2. If the active file is a TLA+ file, read the spec from that file.
3. If lastCheckFiles is populated, use that spec.
4. Error, no spec to check

This PR also refactors the helper functions called by checkModel to return `Result` types. Returning a Result allows the error messages to be ignored in the case where a TLA+ file is not active but the last checked spec is known and can be used. 

As part of the refactoring, I also extracted the `canRunTlc()` checks from functions that get the editor and moved them to the functions that run the TLC tool (`doCheckModel()` and `doEvaluateExpression()`).
